### PR TITLE
Add admin APIs for managing presence monitoring work partitions

### DIFF
--- a/admin/README.md
+++ b/admin/README.md
@@ -95,3 +95,55 @@ keytool -genkey -alias boot \
 
 When prompted for "your first and last name" enter "salus-telemetry-admin-local.area51.rax.io"
 to correspond with the SAML callback location.
+
+## Example Queries
+
+### Declare agent release
+
+```graphql
+mutation DeclareAgentRelease($release:AgentReleaseInput!) {
+  declareAgentRelease(agentRelease:$release) {
+    id
+  }
+}
+```
+
+given
+```json
+{
+  "release": {
+    "type": "TELEGRAF",
+    "os": "DARWIN",
+    "arch": "X86_64",
+    "version": "1.8.0",
+    "url": "https://homebrew.bintray.com/bottles/telegraf-1.8.0.high_sierra.bottle.tar.gz",
+    "exe": "telegraf/1.8.0/bin/telegraf",
+    "checksum": {
+      "value": "655234590790c420dc8a442c78d71e247d39698525d8fad05a05b67006eb07c7875e6b6e7f184203b59a9a82ee3b91af6b24396a4760b3eb9d236470591e6f89",
+      "type": "SHA512"
+    }
+  }
+}
+```
+
+### Change work partition count
+
+```graphql
+mutation 
+{
+  changePresenceMonitorPartitions(count:32) {
+    success
+  }
+}
+```
+
+### Query work partitions
+
+```graphql
+{
+  presenceMonitorPartitions {
+    start
+    end
+  }
+}
+```

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/graphql/ExceptionHandlers.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/graphql/ExceptionHandlers.java
@@ -1,0 +1,14 @@
+package com.rackspace.salus.telemetry.api.graphql;
+
+import graphql.GraphQLException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@Component
+public class ExceptionHandlers {
+
+  @ExceptionHandler
+  public GraphQLException handleIllegalArgument(IllegalArgumentException e) {
+    return new GraphQLException("Illegal argument", e);
+  }
+}

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/graphql/PresenceMonitorMutation.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/graphql/PresenceMonitorMutation.java
@@ -1,0 +1,25 @@
+package com.rackspace.salus.telemetry.api.graphql;
+
+import com.coxautodev.graphql.tools.GraphQLMutationResolver;
+import com.rackspace.salus.telemetry.api.model.SuccessResult;
+import com.rackspace.salus.telemetry.etcd.services.WorkAllocationPartitionService;
+import com.rackspace.salus.telemetry.etcd.types.WorkAllocationRealm;
+import java.util.concurrent.CompletableFuture;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PresenceMonitorMutation implements GraphQLMutationResolver {
+
+  private final WorkAllocationPartitionService workAllocationPartitionService;
+
+  @Autowired
+  public PresenceMonitorMutation(WorkAllocationPartitionService workAllocationPartitionService) {
+    this.workAllocationPartitionService = workAllocationPartitionService;
+  }
+
+  public CompletableFuture<SuccessResult> changePresenceMonitorPartitions(int count) {
+    return workAllocationPartitionService.changePartitions(WorkAllocationRealm.PRESENCE_MONITOR, count)
+        .thenApply(result -> new SuccessResult().setSuccess(result));
+  }
+}

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/graphql/PresenceMonitorQuery.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/graphql/PresenceMonitorQuery.java
@@ -1,0 +1,25 @@
+package com.rackspace.salus.telemetry.api.graphql;
+
+import com.coxautodev.graphql.tools.GraphQLQueryResolver;
+import com.rackspace.salus.telemetry.etcd.services.WorkAllocationPartitionService;
+import com.rackspace.salus.telemetry.etcd.types.KeyRange;
+import com.rackspace.salus.telemetry.etcd.types.WorkAllocationRealm;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PresenceMonitorQuery implements GraphQLQueryResolver {
+
+  private final WorkAllocationPartitionService workAllocationPartitionService;
+
+  @Autowired
+  public PresenceMonitorQuery(WorkAllocationPartitionService workAllocationPartitionService) {
+    this.workAllocationPartitionService = workAllocationPartitionService;
+  }
+
+  public CompletableFuture<List<KeyRange>> presenceMonitorPartitions() {
+    return workAllocationPartitionService.getPartitions(WorkAllocationRealm.PRESENCE_MONITOR);
+  }
+}

--- a/admin/src/main/resources/application.yml
+++ b/admin/src/main/resources/application.yml
@@ -22,6 +22,7 @@ graphql:
     mapping: /graphql
     enabled: true
     corsEnabled: false
+    exception-handlers-enabled: true
 logging:
   level:
     graphql.servlet.internal.ApolloSubscriptionKeepAliveRunner: error

--- a/admin/src/main/resources/mutation.graphqls
+++ b/admin/src/main/resources/mutation.graphqls
@@ -4,4 +4,6 @@ type Mutation {
 
   declareAgentRelease(agentRelease:AgentReleaseInput!) : AgentRelease
   deleteAgentRelease(id:String!) : SuccessResult
+
+  changePresenceMonitorPartitions(count:Int!) : SuccessResult
 }

--- a/admin/src/main/resources/query.graphqls
+++ b/admin/src/main/resources/query.graphqls
@@ -8,4 +8,6 @@ type Query {
   # Queries agent releases. By default all releases are returned. If an id is given then
   # all other criteria are ignored.
   agentReleases(id:String, type:AgentType): [AgentRelease!]!
+
+  presenceMonitorPartitions : [KeyRange!]!
 }

--- a/admin/src/main/resources/types.graphqls
+++ b/admin/src/main/resources/types.graphqls
@@ -70,3 +70,8 @@ input AgentReleaseInput {
 type SuccessResult {
   success: Boolean
 }
+
+type KeyRange {
+  start: String!
+  end: String!
+}

--- a/public/README.md
+++ b/public/README.md
@@ -5,3 +5,80 @@ This module contains the public/tenant facing APIs.
 
 In production, the `secured` Spring profile needs to be activated to enable the processing
 of [Repose KeystoneV2](https://repose.atlassian.net/wiki/spaces/REPOSE/pages/34275336/Keystone+v2+filter) supplied headers.
+
+## Example GraphQL operations
+
+### Create AgentConfig
+
+```graphql
+mutation CreateAgentConfig($config:AgentConfigInput!)
+{
+  createAgentConfig(config:$config) {
+    id
+  }
+}
+```
+
+given
+
+```json
+{
+  "config": {
+    "agentType": "TELEGRAF",
+    "selectorScope": "ALL_OF",
+    "content": "testing",
+    "labels": [
+      {
+        "name": "os",
+        "value": "darwin"
+      }
+    ]
+  }
+}
+```
+
+### Get all AgentConfigs
+
+```graphql
+query GetAllAgentConfigs
+{
+  agentConfigs {
+    id
+    agentType
+    content
+  }
+}
+```
+
+### Get a specific AgentConfig with inline ID
+
+```graphql
+{
+  agentConfigs(id:"d9c3991b-f206-4a30-bf46-6f0cf690bf04") {
+    id
+    agentType
+    content
+  }
+}
+```
+
+### Get a specific AgentConfig with query variables
+
+```graphql
+query GetSpecificAgentConfig($id:String!)
+{
+  agentConfigs(id:$id) {
+    id
+    agentType
+    content
+  }
+}
+```
+
+given 
+
+```json
+{
+  "id": "d9c3991b-f206-4a30-bf46-6f0cf690bf04"
+}
+```


### PR DESCRIPTION
# Resolves

Part of SALUS-75

# What

Adds admin GraphQL query and a mutations for managing the presence monitoring work allocation partitions.

# How

Uses the new service added in https://github.com/racker/salus-telemetry-etcd-adapter/pull/9

## How to test

Manually for now via the GraphiQL UI

# Why

n/a

# TODO

none