### PR TITLE
Consistent with our other apps, only override server port in dev profile

### DIFF
--- a/admin/README.md
+++ b/admin/README.md
@@ -12,8 +12,8 @@ mvn package
 
 # Running locally 
 
-With the default configuration, the Admin API application will run non-secure and bind to port 8888.
-The GraphQL API can be invoked interactively at http://localhost:8888/graphiql
+With the default configuration and the Spring "dev" profile activated, 
+the Admin API application will run non-secure and bind to port 8888.
 
 # Using SAML based authentication for local testing
 

--- a/admin/src/main/resources/application-dev.yml
+++ b/admin/src/main/resources/application-dev.yml
@@ -1,0 +1,2 @@
+server:
+  port: 8888

--- a/admin/src/main/resources/application.yml
+++ b/admin/src/main/resources/application.yml
@@ -15,8 +15,6 @@ management:
         host: ${statsd.host:localhost}
         port: ${statsd.port:8086}
         enabled: ${influx.enabled:false}
-server:
-  port: 8888
 graphql:
   servlet:
     mapping: /graphql


### PR DESCRIPTION
# Resolves

Found during SALUS-93

# What

Only override the default 8080 port when the dev Spring profile is activated.