### PR TITLE
Enable the GraphQL SPQR web GUI

### DIFF
--- a/admin/src/main/resources/application.yml
+++ b/admin/src/main/resources/application.yml
@@ -1,4 +1,3 @@
-
 etcd:
   url: http://localhost:2479
 management.endpoints.web.exposure.include: "health,jolokia,metrics"
@@ -16,11 +15,9 @@ management:
         port: ${statsd.port:8086}
         enabled: ${influx.enabled:false}
 graphql:
-  servlet:
-    mapping: /graphql
-    enabled: true
-    corsEnabled: false
-    exception-handlers-enabled: true
+  spqr:
+    gui:
+      enabled: true
 logging:
   level:
     graphql.servlet.internal.ApolloSubscriptionKeepAliveRunner: error

--- a/public/src/main/resources/application.yml
+++ b/public/src/main/resources/application.yml
@@ -19,8 +19,6 @@ logging:
   level:
     graphql.servlet.internal.ApolloSubscriptionKeepAliveRunner: error
 graphql:
-  servlet:
-    mapping: /graphql
-    enabled: true
-    corsEnabled: false
-    exception-handlers-enabled: true
+  spqr:
+    gui:
+      enabled: true


### PR DESCRIPTION
# Resolves

Discovered during SALUS-98

# What

Enables the built-in GUI that GraphQL SPQR provides so we actually have an endpoint to utilize via the ADFS/SAML authentication.

The GUI is available at `/gui`.

I demoed it one time, but as a reminder, it's the one that looks like

![image](https://user-images.githubusercontent.com/988985/52750964-6a43f200-2fb3-11e9-8f81-921575f7a563.png)
