### PR TITLE
Fine-tune the authenticated paths to ensure actuator can be used

### DIFF
--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/config/AdminWebSecurityConfig.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/config/AdminWebSecurityConfig.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.rackspace.salus.telemetry.api.config;
 
 import java.io.IOException;
@@ -102,8 +118,8 @@ public class AdminWebSecurityConfig extends WebSecurityConfigurerAdapter {
         .and()
         .authorizeRequests()
         .antMatchers("/saml/**").permitAll()
-        // this role constraint is really the only thing specific to our application
-        .anyRequest().hasAnyRole(apiAdminProperties.getRoles())
+        // this path and role constraint is really the only thing specific to our application
+        .antMatchers("/gui", "/graphql").hasAnyRole(apiAdminProperties.getRoles())
     ;
   }
 


### PR DESCRIPTION
# Resolves

Found during SALUS-98

# What

Spring Boot manages securing the `/actuator` endpoint; however, the code before this change was encompassing ALL requests, which defeated the actuator behavior.

# How

Calls out the specific paths to secure, which are the GraphQL GUI and the `/graphql` REST API it uses.

## How to test

I had to start the app with the `secured` profile activated and manually verify.