### PR TITLE
Add support for SAML auth proxy

### DIFF
--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/config/AdminWebSecurityConfig.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/config/AdminWebSecurityConfig.java
@@ -17,6 +17,8 @@
 package com.rackspace.salus.telemetry.api.config;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -45,7 +47,9 @@ import org.springframework.security.saml.SAMLBootstrap;
 import org.springframework.security.saml.SAMLEntryPoint;
 import org.springframework.security.saml.SAMLLogoutFilter;
 import org.springframework.security.saml.SAMLProcessingFilter;
+import org.springframework.security.saml.context.SAMLContextProvider;
 import org.springframework.security.saml.context.SAMLContextProviderImpl;
+import org.springframework.security.saml.context.SAMLContextProviderLB;
 import org.springframework.security.saml.key.JKSKeyManager;
 import org.springframework.security.saml.key.KeyManager;
 import org.springframework.security.saml.log.SAMLDefaultLogger;
@@ -254,7 +258,18 @@ public class AdminWebSecurityConfig extends WebSecurityConfigurerAdapter {
   }
 
   @Bean
-  public SAMLContextProviderImpl contextProvider() {
+  public SAMLContextProvider contextProvider() throws MalformedURLException {
+    if (samlProperties.isUsingLbContextProvider()) {
+      final SAMLContextProviderLB contextProvider = new SAMLContextProviderLB();
+
+      final URL baseUrl = new URL(samlProperties.getEntityBaseUrl());
+      contextProvider.setScheme(baseUrl.getProtocol());
+      contextProvider.setServerName(baseUrl.getHost());
+      contextProvider.setServerPort(baseUrl.getPort());
+      contextProvider.setContextPath(baseUrl.getPath());
+
+      return contextProvider;
+    }
     return new SAMLContextProviderImpl();
   }
 

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/config/ApiAdminProperties.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/config/ApiAdminProperties.java
@@ -1,19 +1,17 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2019 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.rackspace.salus.telemetry.api.config;
@@ -31,4 +29,8 @@ public class ApiAdminProperties {
    * The roles (without "ROLE_" prefix) that are required to allow the user to make use of admin APIs.
    */
   String[] roles = new String[]{"LNX_CLOUD_MMI_ENGINEERS"};
+
+  String userHeader = "x-user-id";
+
+  String groupsHeader = "x-groups";
 }

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/config/DisabledWebSecurityConfig.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/config/DisabledWebSecurityConfig.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.rackspace.salus.telemetry.api.config;
 
 import org.springframework.context.annotation.Configuration;
@@ -6,7 +22,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 
 @Configuration
-@Profile("!secured")
+@Profile("!secured & !proxied-auth")
 public class DisabledWebSecurityConfig extends WebSecurityConfigurerAdapter {
 
   @Override

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/config/ProxiedAuthWebSecurityConfig.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/config/ProxiedAuthWebSecurityConfig.java
@@ -16,7 +16,7 @@
 
 package com.rackspace.salus.telemetry.api.config;
 
-import com.rackspace.salus.common.web.ReposeHeaderFilter;
+import com.rackspace.salus.common.web.PreAuthenticatedFilter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -25,14 +25,14 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 
 @Configuration
-@Profile("secured")
-public class TenantWebSecurityConfig extends WebSecurityConfigurerAdapter {
+@Profile("proxied-auth")
+public class ProxiedAuthWebSecurityConfig extends WebSecurityConfigurerAdapter {
 
-  private final ApiPublicProperties apiPublicProperties;
+  private final ApiAdminProperties properties;
 
   @Autowired
-  public TenantWebSecurityConfig(ApiPublicProperties apiPublicProperties) {
-    this.apiPublicProperties = apiPublicProperties;
+  public ProxiedAuthWebSecurityConfig(ApiAdminProperties properties) {
+    this.properties = properties;
   }
 
   @Override
@@ -40,11 +40,12 @@ public class TenantWebSecurityConfig extends WebSecurityConfigurerAdapter {
     http
         .csrf().disable()
         .addFilterBefore(
-            new ReposeHeaderFilter(),
+            new PreAuthenticatedFilter(properties.getUserHeader(), properties.getGroupsHeader()),
             BasicAuthenticationFilter.class
         )
         .authorizeRequests()
         .antMatchers("/graphql")
-        .hasAnyRole(apiPublicProperties.getRoles());
+        .hasAnyRole(properties.getRoles());
   }
+
 }

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/config/SamlProperties.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/config/SamlProperties.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.rackspace.salus.telemetry.api.config;
 
 import lombok.Data;
@@ -20,4 +36,10 @@ public class SamlProperties {
   int responseSkew = 60;
 
   String entityId = "salus-telemetry-admin-local.area51.rax.io";
+
+  /**
+   * Provides the option to solve SAML issues behind a proxy.
+   * See https://stackoverflow.com/a/24809400/121324
+   */
+  boolean usingLbContextProvider;
 }

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/model/input/AgentRelease.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/model/input/AgentRelease.java
@@ -1,13 +1,36 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.rackspace.salus.telemetry.api.model.input;
 
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.Architecture;
 import com.rackspace.salus.telemetry.model.OperatingSystem;
+import io.leangen.graphql.annotations.GraphQLNonNull;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
-@Data
+@Getter
+@EqualsAndHashCode
+@ToString
+@Setter(onParam = @__({@GraphQLNonNull})) // GraphQL SPQR only looks at the setter property for required-field calculation
 public class AgentRelease {
   @NotBlank
   String version;

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/model/input/ExpectedChecksum.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/model/input/ExpectedChecksum.java
@@ -1,15 +1,45 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.rackspace.salus.telemetry.api.model.input;
 
 import com.rackspace.salus.telemetry.model.Checksum;
+import com.rackspace.salus.telemetry.model.Checksum.Type;
+import io.leangen.graphql.annotations.GraphQLNonNull;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
 
-@Data
+@Getter
+@EqualsAndHashCode
+@ToString
 public class ExpectedChecksum {
   @NotNull
   Checksum.Type type;
 
   @NotEmpty
   String value;
+
+  public void setType(@GraphQLNonNull Type type) {
+    this.type = type;
+  }
+
+  public void setValue(@GraphQLNonNull String value) {
+    this.value = value;
+  }
 }


### PR DESCRIPTION

# Resolves

https://jira.rax.io/browse/SALUS-199

# What

Enable the use of https://github.com/itzg/saml-auth-proxy rather than including the complexity of SAML SP authentication from within the Spring application.

In case the SAML proxy doesn't work out, I also included an option to enable the type of fix [described here](https://stackoverflow.com/questions/24805895/recipient-endpoint-doesnt-match-with-saml-response)

I also discovered GraphQL SPQR is very particular about how it determines a POJO's field should be marked required via the GraphQL schema.

While I was in the code I also noticed the public API's Spring security path was incorrectly still protecting the old `/api` path.

## How to test

I manually tested by enabling the Spring profile `proxied-auth` and using http://localhost:8888/gui with the headers set as:

```json
{
  "x-user-id":"me",
  "x-groups":"lnx-cloud:mmi-engineers"
}
```

If the SAML proxy approach works out, I'll later delete off `AdminWebSecurityConfig` which we were forced to include a whole bunch of boilerplate SAML config.