### PR TITLE
split_cloudbuild: Split cloudbuild.yaml for test vs container deploy

### DIFF
--- a/cloudbuild-deploy.yaml
+++ b/cloudbuild-deploy.yaml
@@ -4,6 +4,25 @@ substitutions:
 
 steps:
 
+    # This is ugly because of
+    # https://github.com/GoogleContainerTools/jib/issues/1500#issuecomment-466207421
+  - id: FIX_DOCKER
+    name: gcr.io/cloud-builders/mvn
+    waitFor: ['-']
+    dir: /root
+    entrypoint: bash
+    args:
+    - -c
+    - # Links the Docker config to /root/.docker/config.json so that Jib picks it up.
+      # Note that this is only a temporary workaround.
+      # See https://github.com/GoogleContainerTools/jib/pull/1479.
+      |
+      mkdir .docker &&
+      ln -vs $$HOME/.docker/config.json .docker/config.json
+    volumes:
+    - name: user.home
+      path: /root
+
   # Pull down settings file for Artifactory settings
   - id: GET_SETTINGS
     name: gcr.io/cloud-builders/gsutil
@@ -34,9 +53,21 @@ steps:
     waitFor:
       - GET_SETTINGS
 
-  - id: DEPLOY_ADMIN
+  - id: COMPILE_AND_PUSH_ADMIN_CONTAINER
     name: 'gcr.io/cloud-builders/mvn'
-    args: ['deploy', "-Dmaven.test.skip=true", "-s", "../.mvn/settings.xml"]
+    env:
+    - 'SHORT_SHA=$SHORT_SHA'
+    args:
+    - compile
+    # Runs the Jib build by using the latest version of the plugin.
+    # To use a specific version, configure the plugin in the pom.xml.
+    - jib:build
+    # Skip Tests since it happened in the previous test
+    - "-Dmaven.test.skip=true"
+    # Ensure we name the image correctly since its not in pom.xml
+    - "-Ddocker.image.prefix=gcr.io/${PROJECT_ID}"
+    - "-s"
+    - ../.mvn/settings.xml
     dir: 'admin'
     volumes:
     - name: user.home
@@ -51,9 +82,21 @@ steps:
     waitFor:
       - GET_SETTINGS
 
-  - id: DEPLOY_PUBLIC
-    name: 'gcr.io/cloud-builders/mvn'
-    args: ['deploy', "-Dmaven.test.skip=true", "-s", "../.mvn/settings.xml"]
+  - id: COMPILE_AND_PUSH_PUBLIC_CONTAINER
+    name: gcr.io/cloud-builders/mvn
+    env:
+    - 'SHORT_SHA=$SHORT_SHA'
+    args:
+    - compile
+    # Runs the Jib build by using the latest version of the plugin.
+    # To use a specific version, configure the plugin in the pom.xml.
+    - jib:build
+    # Skip Tests since it happened in the previous test
+    - "-Dmaven.test.skip=true"
+    # Ensure we name the image correctly since its not in pom.xml
+    - "-Ddocker.image.prefix=gcr.io/${PROJECT_ID}"
+    - "-s"
+    - ../.mvn/settings.xml
     dir: 'public'
     volumes:
     - name: user.home
@@ -64,8 +107,8 @@ steps:
   # Saves the files to the GCS cache.
   - id: PUSH_UP_CACHE
     waitFor:
-      - DEPLOY_ADMIN
-      - DEPLOY_PUBLIC
+      - COMPILE_AND_PUSH_ADMIN_CONTAINER
+      - COMPILE_AND_PUSH_PUBLIC_CONTAINER
     name: gcr.io/cloud-builders/gsutil
     dir: /root
     entrypoint: bash


### PR DESCRIPTION
# Resolves
Jira story/task
* [SALUS-233](https://jira.rax.io/browse/SALUS-233) 
* [SALUS-239](https://jira.rax.io/browse/SALUS-239) 

# What
Splits the cloudbuild.yaml into one for tests/snapshot deploy and one for docker container deployment.

