### PR TITLE
Integrated public API with event engine management backend

### DIFF
--- a/public/README.md
+++ b/public/README.md
@@ -151,3 +151,49 @@ mutation {
   }
 }
 ```
+
+## Event task operations
+
+### Create
+
+```graphql
+mutation {
+  createEventTask(measurement:"cpu", 
+    scenario:{
+      rising: {
+        threshold:50,
+        field:"usage_user"
+      }
+    }) {
+    id
+  }
+}
+```
+
+### Get all
+
+```graphql
+{
+  eventTasks {
+    id
+    measurement
+   	scenarioType
+    scenario {
+      rising {
+        field
+        threshold
+      }
+    }
+  }
+}
+```
+
+### Delete
+
+```graphql
+mutation {
+  deleteEventTask(id:"c435da6d-9596-4780-88bc-b8edccf0a339") {
+    success
+  }
+}
+```

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/graphql/EventTaskApi.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/graphql/EventTaskApi.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.api.graphql;
+
+import com.rackspace.salus.event.manage.model.scenarios.Falling;
+import com.rackspace.salus.event.manage.model.scenarios.Rising;
+import com.rackspace.salus.event.manage.model.scenarios.Scenario;
+import com.rackspace.salus.telemetry.api.model.CreatedEventTask;
+import com.rackspace.salus.telemetry.api.model.DeleteResult;
+import com.rackspace.salus.telemetry.api.model.EventTaskScenario;
+import com.rackspace.salus.telemetry.api.model.RetrievedEventEngineTask;
+import com.rackspace.salus.telemetry.api.services.FrontendEventTaskService;
+import com.rackspace.salus.telemetry.api.services.UserService;
+import io.leangen.graphql.annotations.GraphQLMutation;
+import io.leangen.graphql.annotations.GraphQLNonNull;
+import io.leangen.graphql.annotations.GraphQLQuery;
+import io.leangen.graphql.spqr.spring.annotations.GraphQLApi;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@GraphQLApi
+@Service
+public class EventTaskApi {
+
+  private final FrontendEventTaskService eventTaskService;
+  private final UserService userService;
+
+  @Autowired
+  public EventTaskApi(FrontendEventTaskService eventTaskService, UserService userService) {
+    this.eventTaskService = eventTaskService;
+    this.userService = userService;
+  }
+
+  @GraphQLMutation
+  public CreatedEventTask createEventTask(@GraphQLNonNull String measurement,
+                                          @GraphQLNonNull EventTaskScenario scenario) {
+    final String tenantId = userService.currentTenantId();
+
+    return eventTaskService.create(tenantId, measurement, scenario);
+  }
+
+  @GraphQLQuery
+  public @GraphQLNonNull List<@GraphQLNonNull RetrievedEventEngineTask> eventTasks() {
+    final String tenantId = userService.currentTenantId();
+
+    return eventTaskService.getAll(tenantId).stream()
+        .map(dto -> new RetrievedEventEngineTask()
+            .setId(dto.getId())
+            .setMeasurement(dto.getMeasurement())
+            .setScenario(convertScenario(dto.getScenario()))
+            .setScenarioType(dto.getScenario().getClass().getSimpleName())
+        )
+        .collect(Collectors.toList());
+  }
+
+  private EventTaskScenario convertScenario(Scenario scenario) {
+    final EventTaskScenario eventTaskScenario = new EventTaskScenario();
+
+    // I couldn't get Scenario so work as-is to be a GraphQL union since the abstract Scenario
+    // class itself has no fields and results in this errors from SPQR:
+    // "fields must be an object with field names as keys or a function which returns such an object"
+    if (scenario instanceof Rising) {
+      eventTaskScenario.setRising(((Rising) scenario));
+    } else if (scenario instanceof Falling) {
+      eventTaskScenario.setFalling(((Falling) scenario));
+    }
+    return eventTaskScenario;
+  }
+
+  @GraphQLMutation
+  public DeleteResult deleteEventTask(@GraphQLNonNull String id) {
+    final String tenantId = userService.currentTenantId();
+
+    eventTaskService.delete(tenantId, id);
+
+    return new DeleteResult().setSuccess(true);
+  }
+}

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/model/CreatedEventTask.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/model/CreatedEventTask.java
@@ -14,17 +14,11 @@
  * limitations under the License.
  */
 
-package com.rackspace.salus.telemetry.api.config;
+package com.rackspace.salus.telemetry.api.model;
 
 import lombok.Data;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.stereotype.Component;
 
-@ConfigurationProperties("services")
-@Component
 @Data
-public class ServicesProperties {
-  String monitorManagementUrl = "http://monitor-management:8080";
-  String resourceManagementUrl = "http://resource-management:8080";
-  String eventManagementUrl = "http://event-management:8080";
+public class CreatedEventTask {
+  String id;
 }

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/model/EventTaskScenario.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/model/EventTaskScenario.java
@@ -14,17 +14,14 @@
  * limitations under the License.
  */
 
-package com.rackspace.salus.telemetry.api.config;
+package com.rackspace.salus.telemetry.api.model;
 
+import com.rackspace.salus.event.manage.model.scenarios.Falling;
+import com.rackspace.salus.event.manage.model.scenarios.Rising;
 import lombok.Data;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.stereotype.Component;
 
-@ConfigurationProperties("services")
-@Component
 @Data
-public class ServicesProperties {
-  String monitorManagementUrl = "http://monitor-management:8080";
-  String resourceManagementUrl = "http://resource-management:8080";
-  String eventManagementUrl = "http://event-management:8080";
+public class EventTaskScenario {
+  Falling falling;
+  Rising rising;
 }

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/model/RetrievedEventEngineTask.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/model/RetrievedEventEngineTask.java
@@ -14,17 +14,15 @@
  * limitations under the License.
  */
 
-package com.rackspace.salus.telemetry.api.config;
+package com.rackspace.salus.telemetry.api.model;
 
+import java.util.UUID;
 import lombok.Data;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.stereotype.Component;
 
-@ConfigurationProperties("services")
-@Component
 @Data
-public class ServicesProperties {
-  String monitorManagementUrl = "http://monitor-management:8080";
-  String resourceManagementUrl = "http://resource-management:8080";
-  String eventManagementUrl = "http://event-management:8080";
+public class RetrievedEventEngineTask {
+  UUID id;
+  String measurement;
+  String scenarioType;
+  EventTaskScenario scenario;
 }

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/services/FrontendEventTaskService.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/services/FrontendEventTaskService.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.api.services;
+
+import com.rackspace.salus.event.manage.model.CreateTask;
+import com.rackspace.salus.event.manage.model.CreateTaskResponse;
+import com.rackspace.salus.event.manage.model.EventEngineTaskDTO;
+import com.rackspace.salus.telemetry.api.config.ServicesProperties;
+import com.rackspace.salus.telemetry.api.model.BackendRestException;
+import com.rackspace.salus.telemetry.api.model.CreatedEventTask;
+import com.rackspace.salus.telemetry.api.model.EventTaskScenario;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class FrontendEventTaskService {
+
+  private final RestTemplate eventTaskRest;
+
+  @Autowired
+  public FrontendEventTaskService(ServicesProperties servicesProperties,
+                                  RestTemplateBuilder restTemplateBuilder) {
+    this.eventTaskRest = restTemplateBuilder
+        .rootUri(servicesProperties.getEventManagementUrl())
+        .build();
+  }
+
+  public CreatedEventTask create(String tenantId,
+                                 String measurement,
+                                 EventTaskScenario scenario) {
+
+    final CreateTask createTask = new CreateTask()
+        .setMeasurement(measurement);
+
+    // GraphQL currently lacks unions on input types, so we need to do this dance
+    if (scenario.getFalling() != null && createTask.getScenario() == null) {
+      createTask.setScenario(scenario.getFalling());
+    }
+    else if (scenario.getRising() != null && createTask.getScenario() == null) {
+      createTask.setScenario(scenario.getRising());
+    }
+    else {
+      throw new IllegalArgumentException("One and only one scenario can be given");
+    }
+
+    final CreateTaskResponse response = eventTaskRest.postForObject(
+        "/api/tasks/{tenantId}",
+        createTask,
+        CreateTaskResponse.class,
+        tenantId
+    );
+
+    return new CreatedEventTask().setId(response.getId().toString());
+  }
+
+  public List<EventEngineTaskDTO> getAll(String tenantId) {
+    final ResponseEntity<List<EventEngineTaskDTO>> response = eventTaskRest.exchange(
+        "/api/tasks/{tenantId}",
+        HttpMethod.GET,
+        null,
+        new ParameterizedTypeReference<List<EventEngineTaskDTO>>() {
+        },
+        tenantId
+    );
+
+    if (response.getStatusCode().isError()) {
+      throw new BackendRestException("Trying to get event tasks", response);
+    }
+
+    return response.getBody();
+  }
+
+  public void delete(String tenantId, String id) {
+    eventTaskRest.delete(
+        "/api/tasks/{tenantId}/{taskId}",
+        tenantId, id
+    );
+  }
+}

--- a/public/src/main/resources/application-dev.yml
+++ b/public/src/main/resources/application-dev.yml
@@ -5,3 +5,4 @@ logging:
 services:
   monitor-management-url: http://localhost:8089
   resource-management-url: http://localhost:8085
+  event-management-url: http://localhost:8087


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-190

# What

Adds GraphQL query and mutations to integrate with the Event Engine management backend.

These changes were what fueled some of my anti-GraphQL comments over in the other PR
https://github.com/racker/salus-telemetry-api/pull/20#discussion_r262755451

I encountered more awkwardness with polymorphic configuration classes needed for the event task scenarios.