### PR TITLE
Stop simultaneously building pom cloudbuild AND quiet it down

### DIFF
--- a/cloudbuild-deploy.yaml
+++ b/cloudbuild-deploy.yaml
@@ -48,10 +48,10 @@ steps:
 
   - id: ADMIN_INTEGRATION_TEST
     name: gcr.io/cloud-builders/mvn
-    args: ['integration-test', '-s', '../.mvn/settings.xml']
+    args: ['integration-test', '-s', '../.mvn/settings.xml', '-B', '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn']
     dir: 'admin'
     waitFor:
-      - GET_SETTINGS
+      - PULL_DOWN_CACHE
 
   - id: COMPILE_AND_PUSH_ADMIN_CONTAINER
     name: 'gcr.io/cloud-builders/mvn'
@@ -68,19 +68,17 @@ steps:
     - "-Ddocker.image.prefix=gcr.io/${PROJECT_ID}"
     - "-s"
     - ../.mvn/settings.xml
+    - "-B"
+    - "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
     dir: 'admin'
     volumes:
     - name: user.home
       path: /root
-    waitFor:
-      - ADMIN_INTEGRATION_TEST
 
   - id: PUBLIC_INTEGRATION_TEST
     name: gcr.io/cloud-builders/mvn
-    args: ['integration-test', '-s', '../.mvn/settings.xml']
+    args: ['integration-test', '-s', '../.mvn/settings.xml', '-B', '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn']
     dir: 'admin'
-    waitFor:
-      - GET_SETTINGS
 
   - id: COMPILE_AND_PUSH_PUBLIC_CONTAINER
     name: gcr.io/cloud-builders/mvn
@@ -97,12 +95,12 @@ steps:
     - "-Ddocker.image.prefix=gcr.io/${PROJECT_ID}"
     - "-s"
     - ../.mvn/settings.xml
+    - "-B"
+    - "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
     dir: 'public'
     volumes:
     - name: user.home
       path: /root
-    waitFor:
-      - PUBLIC_INTEGRATION_TEST
 
   # Saves the files to the GCS cache.
   - id: PUSH_UP_CACHE

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -32,7 +32,7 @@ steps:
     args: ['integration-test', '-s', '../.mvn/settings.xml']
     dir: 'admin'
     waitFor:
-      - GET_SETTINGS
+      - PULL_DOWN_CACHE
 
   - id: DEPLOY_ADMIN
     name: 'gcr.io/cloud-builders/mvn'
@@ -41,25 +41,19 @@ steps:
     volumes:
     - name: user.home
       path: /root
-    waitFor:
-      - ADMIN_INTEGRATION_TEST
 
   - id: PUBLIC_INTEGRATION_TEST
     name: gcr.io/cloud-builders/mvn
     args: ['integration-test', '-s', '../.mvn/settings.xml']
     dir: 'admin'
-    waitFor:
-      - GET_SETTINGS
 
   - id: DEPLOY_PUBLIC
     name: 'gcr.io/cloud-builders/mvn'
-    args: ['deploy', "-Dmaven.test.skip=true", "-s", "../.mvn/settings.xml"]
+    args: ['deploy', "-Dmaven.test.skip=true", "-X", "-s", "../.mvn/settings.xml"]
     dir: 'public'
     volumes:
     - name: user.home
       path: /root
-    waitFor:
-      - PUBLIC_INTEGRATION_TEST
 
   # Saves the files to the GCS cache.
   - id: PUSH_UP_CACHE

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -29,14 +29,14 @@ steps:
 
   - id: ADMIN_INTEGRATION_TEST
     name: gcr.io/cloud-builders/mvn
-    args: ['integration-test', '-s', '../.mvn/settings.xml']
+    args: ['integration-test', '-s', '../.mvn/settings.xml', '--batch-mode', '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn']
     dir: 'admin'
     waitFor:
       - PULL_DOWN_CACHE
 
   - id: DEPLOY_ADMIN
     name: 'gcr.io/cloud-builders/mvn'
-    args: ['deploy', "-Dmaven.test.skip=true", "-s", "../.mvn/settings.xml"]
+    args: ['deploy', "-Dmaven.test.skip=true", "-s", "../.mvn/settings.xml", '--batch-mode', '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn']
     dir: 'admin'
     volumes:
     - name: user.home
@@ -44,12 +44,12 @@ steps:
 
   - id: PUBLIC_INTEGRATION_TEST
     name: gcr.io/cloud-builders/mvn
-    args: ['integration-test', '-s', '../.mvn/settings.xml']
+    args: ['integration-test', '-s', '../.mvn/settings.xml', '--batch-mode', '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn']
     dir: 'admin'
 
   - id: DEPLOY_PUBLIC
     name: 'gcr.io/cloud-builders/mvn'
-    args: ['deploy', "-Dmaven.test.skip=true", "-X", "-s", "../.mvn/settings.xml"]
+    args: ['deploy', "-Dmaven.test.skip=true", "-s", "../.mvn/settings.xml", '--batch-mode', '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn']
     dir: 'public'
     volumes:
     - name: user.home

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -29,14 +29,14 @@ steps:
 
   - id: ADMIN_INTEGRATION_TEST
     name: gcr.io/cloud-builders/mvn
-    args: ['integration-test', '-s', '../.mvn/settings.xml', '--batch-mode', '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn']
+    args: ['integration-test', '-s', '../.mvn/settings.xml', '-B', '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn']
     dir: 'admin'
     waitFor:
       - PULL_DOWN_CACHE
 
   - id: DEPLOY_ADMIN
     name: 'gcr.io/cloud-builders/mvn'
-    args: ['deploy', "-Dmaven.test.skip=true", "-s", "../.mvn/settings.xml", '--batch-mode', '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn']
+    args: ['deploy', "-Dmaven.test.skip=true", "-s", "../.mvn/settings.xml", '-B', '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn']
     dir: 'admin'
     volumes:
     - name: user.home
@@ -44,12 +44,12 @@ steps:
 
   - id: PUBLIC_INTEGRATION_TEST
     name: gcr.io/cloud-builders/mvn
-    args: ['integration-test', '-s', '../.mvn/settings.xml', '--batch-mode', '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn']
+    args: ['integration-test', '-s', '../.mvn/settings.xml', '-B', '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn']
     dir: 'admin'
 
   - id: DEPLOY_PUBLIC
     name: 'gcr.io/cloud-builders/mvn'
-    args: ['deploy', "-Dmaven.test.skip=true", "-s", "../.mvn/settings.xml", '--batch-mode', '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn']
+    args: ['deploy', "-Dmaven.test.skip=true", "-s", "../.mvn/settings.xml", '-B', '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn']
     dir: 'public'
     volumes:
     - name: user.home


### PR DESCRIPTION
# Resolves
This slows down the build, but it should work every time.  While the simultaneous `mvn deploy` of both admin and public was a good idea for speed up the process, but it may be corrupting the pom.

Using this blog to find how to remove "[INFO] Downloaded from":
https://blogs.itemis.com/en/in-a-nutshell-removing-artifact-messages-from-maven-log-output

# How
Removed the [waitFor] directive and the builds are happening one at a time in the cloudbuild.yaml
Using library to quiet down the very loud logs.