### PR TITLE
Update AgentRelease handling for namespaced labels

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,23 @@
 # Resolves
 
-    <Jira or Github issue reference(s)>
+<Jira or Github issue reference(s)>
 
 # What
 
-    <What is this PR is trying to accomplish?>
+<What is this PR is trying to accomplish?>
 
 # How
 
-    <How is the PR designed to solve the problem?>
+<How is the PR designed to solve the problem?>
 
 ## How to test
 
-    <instructions for verifying the changes specific to this PR>
+<instructions for verifying the changes specific to this PR>
 
 # Why
 
-    <Why was the final approach taken? Were alternatives considered?>
+<Why was the final approach taken? Were alternatives considered?>
 
 # TODO
 
-    <outstanding tasks before this PR is considered 'ready'>
+<outstanding tasks before this PR is considered 'ready'>

--- a/admin/README.md
+++ b/admin/README.md
@@ -119,18 +119,26 @@ mutation DeclareAgentRelease($release:AgentReleaseInput!) {
 given
 ```json
 {
-  "release": {
-    "type": "TELEGRAF",
-    "os": "DARWIN",
-    "arch": "X86_64",
-    "version": "1.8.0",
-    "url": "https://homebrew.bintray.com/bottles/telegraf-1.8.0.high_sierra.bottle.tar.gz",
-    "exe": "telegraf/1.8.0/bin/telegraf",
-    "checksum": {
-      "value": "655234590790c420dc8a442c78d71e247d39698525d8fad05a05b67006eb07c7875e6b6e7f184203b59a9a82ee3b91af6b24396a4760b3eb9d236470591e6f89",
-      "type": "SHA512"
-    }
-  }
+	"release": {
+		"type": "TELEGRAF",
+		"version": "1.9.4",
+		"labelSelector": [
+			{
+				"name": "agent_discovered_os",
+				"value": "darwin"
+			},
+			{
+				"name": "agent_discovered_arch",
+				"value": "amd64"
+			}
+		],
+		"url": "https://homebrew.bintray.com/bottles/telegraf-1.9.4.high_sierra.bottle.tar.gz",
+		"exe": "telegraf/1.9.4/bin/telegraf",
+		"checksum": {
+			"value": "",
+			"type": "SHA512"
+		}
+	}
 }
 ```
 

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/config/ApiAdminProperties.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/config/ApiAdminProperties.java
@@ -16,6 +16,9 @@
 
 package com.rackspace.salus.telemetry.api.config;
 
+import com.rackspace.salus.telemetry.model.LabelNamespaces;
+import java.util.Arrays;
+import java.util.List;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
@@ -33,4 +36,13 @@ public class ApiAdminProperties {
   String userHeader = "x-user-id";
 
   String groupsHeader = "x-groups";
+
+  /**
+   * When registering an agent release, these are the labels that are required to be present
+   * in the selector.
+   */
+  List<String> requiredAgentLabels = Arrays.asList(
+      LabelNamespaces.applyNamespace(LabelNamespaces.AGENT, "discovered_os"),
+      LabelNamespaces.applyNamespace(LabelNamespaces.AGENT, "discovered_arch")
+  );
 }

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/graphql/AgentsCatalogMutation.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/graphql/AgentsCatalogMutation.java
@@ -1,39 +1,43 @@
 package com.rackspace.salus.telemetry.api.graphql;
 
+import com.rackspace.salus.telemetry.api.config.ApiAdminProperties;
 import com.rackspace.salus.telemetry.api.model.SuccessResult;
 import com.rackspace.salus.telemetry.api.model.input.AgentRelease;
 import com.rackspace.salus.telemetry.etcd.services.AgentsCatalogService;
-import com.rackspace.salus.telemetry.model.Architecture;
 import com.rackspace.salus.telemetry.model.Checksum;
 import com.rackspace.salus.telemetry.model.Label;
-import com.rackspace.salus.telemetry.model.OperatingSystem;
 import io.leangen.graphql.annotations.GraphQLMutation;
 import io.leangen.graphql.spqr.spring.annotations.GraphQLApi;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.util.Assert;
 
 @Service
 @GraphQLApi
 public class AgentsCatalogMutation {
 
   private final AgentsCatalogService agentsCatalogService;
+  private final ApiAdminProperties properties;
 
   @Autowired
-  public AgentsCatalogMutation(AgentsCatalogService agentsCatalogService) {
+  public AgentsCatalogMutation(AgentsCatalogService agentsCatalogService, ApiAdminProperties properties) {
     this.agentsCatalogService = agentsCatalogService;
+    this.properties = properties;
   }
 
   @GraphQLMutation
   public CompletableFuture<com.rackspace.salus.telemetry.model.AgentRelease> declareAgentRelease(AgentRelease input) {
-    Assert.isTrue(containsLabel(input, OperatingSystem.NAME), "Missing required label: "+OperatingSystem.NAME);
-    Assert.isTrue(containsLabel(input, Architecture.NAME), "Missing required label: "+Architecture.NAME);
+    if (!properties.getRequiredAgentLabels().stream()
+        .allMatch(s -> containsLabel(input, s))) {
+      throw new IllegalArgumentException(
+          "AgentRelease is missing one or more required labels: " + properties.getRequiredAgentLabels()
+      );
+    };
 
     final com.rackspace.salus.telemetry.model.AgentRelease agentRelease = new com.rackspace.salus.telemetry.model.AgentRelease()
         .setType(input.getType())
         .setUrl(input.getUrl())
-        .setLabels(Label.convertToMap(input.getLabels()))
+        .setLabels(Label.convertToMap(input.getLabelSelector()))
         .setVersion(input.getVersion())
         .setExe(input.getExe())
         ;
@@ -50,11 +54,11 @@ public class AgentsCatalogMutation {
   }
 
   private static boolean containsLabel(AgentRelease input, String name) {
-    if (input.getLabels() == null) {
+    if (input.getLabelSelector() == null) {
       return false;
     }
 
-    for (Label label : input.getLabels()) {
+    for (Label label : input.getLabelSelector()) {
       if (label.getName().equals(name)) {
         return true;
       }

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/model/input/AgentRelease.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/model/input/AgentRelease.java
@@ -35,7 +35,7 @@ public class AgentRelease {
   AgentType type;
 
   @NotNull
-  List<@GraphQLNonNull Label> labels;
+  List<@GraphQLNonNull Label> labelSelector;
 
   @NotBlank
   String url;

--- a/public/README.md
+++ b/public/README.md
@@ -15,139 +15,43 @@ of [Repose KeystoneV2](https://repose.atlassian.net/wiki/spaces/REPOSE/pages/342
 
 ## Agent Installation Operations
 
-### Install Agent Release
+### Get Agent Releases
 
-```graphql
-mutation InstallAgentRelease($releaseId:String!, $labels:[LabelInput!]!)
-{
-  installAgentRelease(agentReleaseId:$releaseId, labels:$labels) {
-    id
-  }
-}
+```
+GET localhost:8080/api/agentReleases
 ```
 
-given
+### Install Agent Release
 
-```json
+```
+POST localhost:8080/api/agentInstalls
+Content-Type: application/json
+
 {
-  "releaseId": "ea99d592-fbc3-452a-9b17-5b0e0b1325bd",
-  "labels": [
-    {
-      "name": "os",
-      "value": "DARWIN"
-    }
-  ]
+	"agentReleaseId": "e93149f7-79de-4517-940c-4c956166e5e3",
+	"labelSelector": {
+		"agent_discovered_os": "darwin"
+	}
 }
 ```
 
 ## Monitor Operations
 
-### Create monitor
+To be documented...
 
-```graphql
-mutation {
-  createLocalMonitor(
-    matchingLabels: [{ name: "os", value: "DARWIN" }]
-    configs: {
-      usingTelegraf: { 
-        mem: { enabled: true }, 
-        cpu: { enabled: true },
-      	disk: { enabled:true, mountPoints:"/var/lib" }
-      }
-    }
-  ) {
-    id
-  }
-}
-```
+### Create monitor
 
 ### Get all monitors
 
-```graphql
-{
-  monitors {
-    totalElements
-    first
-    last
-    content {
-      id
-      matchingLabels {
-        name
-        value
-      }
-      configs {
-        local {
-          usingTelegraf {
-            enabled
-            configJson
-          }
-        }
-      }
-    }
-  }
-}
-```
-
 ### Delete monitor
 
-```graphql
-mutation {
-  deleteMonitor(id:"e20d16c0-c1dd-46f6-8cac-577100c0f341") {
-    success
-  }
-}
-```
 
 ## Resource Operations
 
+To be documented...
+
 ### Create a resource
 
-```graphql
-mutation {
-  createResource(resourceId:"testing2", 
-    labels:[{name:"test",value:"true"}]) {
-    resourceId
-    id
-  }
-}
-```
-
 ### Get all resources
-```graphql
-{
-  resources {
-    content {
-      id
-      resourceId
-      labels
-    }
-  }
-}
-```
-
-### Get a page of resources
-```graphql
-{
-  resources(size:1, page:1) {
-    first
-    last
-    totalPages
-    content {
-      id
-      resourceId
-      labels
-    }
-  }
-}
-```
 
 ### Delete a resource
-Must specify the identifierName and value.
-
-```graphql
-mutation {
-  deleteResource(resourceId:"testing2") {
-    success
-  }
-}
-```

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/model/AgentInstallation.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/model/AgentInstallation.java
@@ -1,7 +1,6 @@
 package com.rackspace.salus.telemetry.api.model;
 
-import com.rackspace.salus.telemetry.model.Label;
-import java.util.List;
+import java.util.Map;
 import lombok.Data;
 
 @Data
@@ -10,5 +9,5 @@ public class AgentInstallation {
 
   String agentReleaseId;
 
-  List<Label> matchingLabels;
+  Map<String,String> labelSelector;
 }

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/model/InstallAgent.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/model/InstallAgent.java
@@ -26,5 +26,5 @@ public class InstallAgent {
   String agentReleaseId;
 
   @NotEmpty
-  Map<String,String> matchingLabels;
+  Map<String,String> labelSelector;
 }

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/AgentInstallationController.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/AgentInstallationController.java
@@ -21,7 +21,6 @@ import com.rackspace.salus.telemetry.api.model.InstallAgent;
 import com.rackspace.salus.telemetry.api.services.UserService;
 import com.rackspace.salus.telemetry.etcd.services.AgentsCatalogService;
 import com.rackspace.salus.telemetry.etcd.types.AgentInstallSelector;
-import com.rackspace.salus.telemetry.model.Label;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -63,7 +62,7 @@ public class AgentInstallationController {
                     new AgentInstallation()
                         .setId(selector.getId())
                         .setAgentReleaseId(selector.getAgentReleaseId())
-                        .setMatchingLabels(Label.convertToLabelList(selector.getLabels()))
+                        .setLabelSelector(selector.getLabels())
                 )
                 .collect(Collectors.toList())
         );
@@ -82,13 +81,13 @@ public class AgentInstallationController {
         tenantId,
         new AgentInstallSelector()
             .setAgentReleaseId(agentReleaseId)
-            .setLabels(install.getMatchingLabels())
+            .setLabels(install.getLabelSelector())
     )
         .thenApply(result ->
             new AgentInstallation()
                 .setId(result.getId())
                 .setAgentReleaseId(result.getAgentReleaseId())
-                .setMatchingLabels(Label.convertToLabelList(result.getLabels()))
+                .setLabelSelector(result.getLabels())
         );
   }
 }


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-370

# What

The agent release mutation handler was still asserting the old, not-namespaced labels.

# How

Simplify and improve robustness by declaring required labels as properties.

## How to test

Manual testing. We lack unit tests for admin API so far :(