### PR TITLE
Update allowed public api access roles

### DIFF
--- a/public/src/main/java/com/rackspace/salus/telemetry/api/config/ApiPublicProperties.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/config/ApiPublicProperties.java
@@ -27,8 +27,12 @@ import org.springframework.stereotype.Component;
 @Data
 public class ApiPublicProperties {
 
+  private static final String serviceAdminRole = "MONITORING_SERVICE_ADMIN";
+  private static final String accountOwnerRole = "IDENTITY_USER_ADMIN";
+  private static final String accountDefaultRole = "IDENTITY_DEFAULT";
+
   /**
    * The roles (without "ROLE_" prefix) that are required to allow the user to make use of tenant APIs.
    */
-  String[] roles = new String[]{"COMPUTE_USER"};
+  String[] roles = new String[]{};
 }

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/config/ApiPublicProperties.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/config/ApiPublicProperties.java
@@ -34,5 +34,5 @@ public class ApiPublicProperties {
   /**
    * The roles (without "ROLE_" prefix) that are required to allow the user to make use of tenant APIs.
    */
-  String[] roles = new String[]{};
+  String[] roles = new String[]{serviceAdminRole, accountOwnerRole, accountDefaultRole};
 }

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/config/ApiPublicProperties.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/config/ApiPublicProperties.java
@@ -33,6 +33,7 @@ public class ApiPublicProperties {
 
   /**
    * The roles (without "ROLE_" prefix) that are required to allow the user to make use of tenant APIs.
+   * Identity roles are translated to this format via {@link com.rackspace.salus.common.web.PreAuthenticatedFilter}.
    */
   String[] roles = new String[]{serviceAdminRole, accountOwnerRole, accountDefaultRole};
 }


### PR DESCRIPTION
# What

Updates the roles that we allow to have access to the public api.

# Why

`COMPUTE_USER` was a placeholder.  I think these three roles should cover everyone that needs access.

Customers will have one of the `account` roles.
Rackers will have the same since they will be impersonating the customer.
RBA et al. will use their service account that must have the service admin role.