### PR TITLE
Set empty default roles

### DIFF
--- a/public/src/main/java/com/rackspace/salus/telemetry/api/config/ApiPublicProperties.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/config/ApiPublicProperties.java
@@ -29,6 +29,7 @@ public class ApiPublicProperties {
 
   /**
    * The roles (without "ROLE_" prefix) that are required to allow the user to make use of tenant APIs.
+   * Identity roles are translated to this format via {@link com.rackspace.salus.common.web.PreAuthenticatedFilter}.
    */
-  String[] roles = new String[]{"COMPUTE_USER"};
+  String[] roles = new String[]{};
 }


### PR DESCRIPTION
This replaces https://github.com/racker/salus-telemetry-api/pull/34

The default will be set to empty, and the real roles will be added as part of the deployment via helm.  A jira has been created for that part.