### PR TITLE
Move presence monitoring api out and just proxy to that service instead

### DIFF
--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -75,11 +75,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>com.rackspace.salus</groupId>
-            <artifactId>salus-telemetry-etcd-adapter</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
-        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/TelemetryAdminApiApplication.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/TelemetryAdminApiApplication.java
@@ -18,12 +18,10 @@
 
 package com.rackspace.salus.telemetry.api;
 
-import com.rackspace.salus.telemetry.etcd.EnableEtcd;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-@EnableEtcd
 public class TelemetryAdminApiApplication {
 
     public static void main(String[] args) {

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/config/ApiAdminProperties.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/config/ApiAdminProperties.java
@@ -32,9 +32,7 @@ public class ApiAdminProperties {
    * The roles (without "ROLE_" prefix) that are required to allow the user to make use of tenant APIs.
    * Identity roles are translated to this format via {@link com.rackspace.salus.common.web.PreAuthenticatedFilter}.
    */
-  String[] roles = new String[]{"BLAH","MONITORING_SERVICE_ADMIN"};
-  // we should maybe have a new role created in identity and assigned to our own service account
-  // if we don't do that we'd always have to use saml to auth
+  String[] roles = new String[]{};
 
   /**
    * When registering an agent release, these are the labels that are required to be present

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/config/ApiAdminProperties.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/config/ApiAdminProperties.java
@@ -32,7 +32,7 @@ public class ApiAdminProperties {
    * The roles (without "ROLE_" prefix) that are required to allow the user to make use of tenant APIs.
    * Identity roles are translated to this format via {@link com.rackspace.salus.common.web.PreAuthenticatedFilter}.
    */
-  String[] roles = new String[]{};
+  String[] roles = new String[]{"BLAH","MONITORING_SERVICE_ADMIN"};
   // we should maybe have a new role created in identity and assigned to our own service account
   // if we don't do that we'd always have to use saml to auth
 

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/config/ServicesProperties.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/config/ServicesProperties.java
@@ -27,4 +27,5 @@ public class ServicesProperties {
   String monitorManagementUrl = "http://monitor-management:8080";
   String resourceManagementUrl = "http://resource-management:8080";
   String eventManagementUrl = "http://event-management:8080";
+  String presenceMonitorUrl = "http://presence-monitor:8083";
 }

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/model/SuccessResult.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/model/SuccessResult.java
@@ -1,8 +1,0 @@
-package com.rackspace.salus.telemetry.api.model;
-
-import lombok.Data;
-
-@Data
-public class SuccessResult {
-  boolean success;
-}

--- a/admin/src/main/resources/application-dev.yml
+++ b/admin/src/main/resources/application-dev.yml
@@ -2,8 +2,9 @@ server:
   port: 8888
 logging:
   level:
-    com.rackspace.salus.telemetry.api: debug
+    com.rackspace.salus: debug
 services:
   monitor-management-url: http://localhost:8089
   resource-management-url: http://localhost:8085
   event-management-url: http://localhost:8087
+  presence-monitor-url: http://localhost:8083


### PR DESCRIPTION
# What

Updates the admin API to proxy presence monitoring requests vs. doing the etcd logic itself.

# How

Moves all the real logic to the presence monitoring service, and updated the api controller here to proxy just like we do for every other service.

## How to test

I've tested manually.

# Why

This makes things consistent and also removes the need for the api to interact directly with etcd.

# TODO

This relates to https://github.com/racker/salus-common/pull/20
and an upcoming presence-monitor PR.

Need to add `presence-monitor-url:` to helm.