### PR TITLE
Remove direct use of etcd and proxy to agent catalog management

### DIFF
--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -85,11 +85,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>com.rackspace.salus</groupId>
-            <artifactId>salus-telemetry-etcd-adapter</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
-        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/TelemetryAdminApiApplication.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/TelemetryAdminApiApplication.java
@@ -16,12 +16,10 @@
 
 package com.rackspace.salus.telemetry.api;
 
-import com.rackspace.salus.telemetry.etcd.EnableEtcd;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-@EnableEtcd
 public class TelemetryAdminApiApplication {
 
     public static void main(String[] args) {

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/config/ServicesProperties.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/config/ServicesProperties.java
@@ -16,6 +16,7 @@
 
 package com.rackspace.salus.telemetry.api.config;
 
+import javax.validation.constraints.NotEmpty;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
@@ -24,8 +25,14 @@ import org.springframework.stereotype.Component;
 @Component
 @Data
 public class ServicesProperties {
+  @NotEmpty
   String monitorManagementUrl = "http://monitor-management:8080";
+  @NotEmpty
   String resourceManagementUrl = "http://resource-management:8080";
+  @NotEmpty
   String eventManagementUrl = "http://event-management:8080";
-  String presenceMonitorUrl = "http://presence-monitor:8083";
+  @NotEmpty
+  String presenceMonitorUrl = "http://presence-monitor:8080";
+  @NotEmpty
+  String agentCatalogManagementUrl = "http://agent-catalog-management:8080";
 }

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/web/AgentReleasesController.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/web/AgentReleasesController.java
@@ -50,7 +50,7 @@ public class AgentReleasesController {
         .path("/api/admin/agent-releases")
         .queryParams(queryParams)
         .build()
-        .toString();
+        .toUriString();
 
     return proxy.uri(backendUri).get();
   }
@@ -74,7 +74,7 @@ public class AgentReleasesController {
         .fromUriString(servicesProperties.getAgentCatalogManagementUrl())
         .path("/api/admin/agent-releases")
         .build()
-        .toString();
+        .toUriString();
 
     return proxy.uri(backendUri).post();
   }

--- a/admin/src/main/resources/application-dev.yml
+++ b/admin/src/main/resources/application-dev.yml
@@ -8,3 +8,4 @@ services:
   resource-management-url: http://localhost:8085
   event-management-url: http://localhost:8087
   presence-monitor-url: http://localhost:8083
+  agent-catalog-management-url: http://localhost:8090

--- a/public/pom.xml
+++ b/public/pom.xml
@@ -82,11 +82,6 @@
         </dependency>
         <dependency>
             <groupId>com.rackspace.salus</groupId>
-            <artifactId>salus-telemetry-etcd-adapter</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>com.rackspace.salus</groupId>
             <artifactId>salus-common</artifactId>
             <version>0.1.0-SNAPSHOT</version>
         </dependency>

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/TelemetryPublicApiApplication.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/TelemetryPublicApiApplication.java
@@ -1,29 +1,25 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2019 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.rackspace.salus.telemetry.api;
 
-import com.rackspace.salus.telemetry.etcd.EnableEtcd;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-@EnableEtcd
 public class TelemetryPublicApiApplication {
 
     public static void main(String[] args) {

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/config/ServicesProperties.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/config/ServicesProperties.java
@@ -16,6 +16,7 @@
 
 package com.rackspace.salus.telemetry.api.config;
 
+import javax.validation.constraints.NotEmpty;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
@@ -24,7 +25,12 @@ import org.springframework.stereotype.Component;
 @Component
 @Data
 public class ServicesProperties {
+  @NotEmpty
   String monitorManagementUrl = "http://monitor-management:8080";
+  @NotEmpty
   String resourceManagementUrl = "http://resource-management:8080";
+  @NotEmpty
   String eventManagementUrl = "http://event-management:8080";
+  @NotEmpty
+  String agentCatalogManagementUrl = "http://agent-catalog-management:8080";
 }

--- a/public/src/main/resources/application-dev.yml
+++ b/public/src/main/resources/application-dev.yml
@@ -6,3 +6,4 @@ services:
   monitor-management-url: http://localhost:8089
   resource-management-url: http://localhost:8085
   event-management-url: http://localhost:8087
+  agent-catalog-management-url: http://localhost:8090


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-302

# What

The agent catalog and installations via etcd were the final remaining reasons the api proxies still accessed etcd directly. Now the catalog and installs are managed by a new service that uses SQL.

# How

Removes the temporary re-introduction of etcd usage into the admin and public API services. Instead, it proxies to the new agent catalog management service.