### PR TITLE
Proxy APIs to retrieve resource and monitor labels and metadata

### DIFF
--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorsController.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorsController.java
@@ -96,6 +96,18 @@ public class MonitorsController {
     return proxy.uri(backendUri).delete();
   }
 
+  @GetMapping("/tenant/{tenantId}/monitor-label-selectors")
+  public ResponseEntity<?> getMonitorLabelSelectors(ProxyExchange<?> proxy,
+                                                    @PathVariable String tenantId) {
+    final String backendUri = UriComponentsBuilder
+        .fromUriString(servicesProperties.getMonitorManagementUrl())
+        .path("/api/tenant/{tenantId}/monitor-label-selectors")
+        .build(tenantId)
+        .toString();
+
+    return proxy.uri(backendUri).get();
+  }
+
   @GetMapping("/tenant/{tenantId}/bound-monitors")
   public ResponseEntity<?> getAllBoundMonitors(ProxyExchange<?> proxy,
                                                @PathVariable String tenantId,

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/ResourcesController.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/ResourcesController.java
@@ -77,6 +77,42 @@ public class ResourcesController {
     return proxy.uri(backendUri).get();
   }
 
+  @GetMapping("/tenant/{tenantId}/resource-labels")
+  public ResponseEntity<?> getResourceLabels(ProxyExchange<?> proxy,
+                                             @PathVariable String tenantId) {
+    final String backendUri = UriComponentsBuilder
+        .fromUriString(servicesProperties.getResourceManagementUrl())
+        .path("/api/tenant/{tenantId}/resource-labels")
+        .build(tenantId)
+        .toString();
+
+    return proxy.uri(backendUri).get();
+  }
+
+  @GetMapping("/tenant/{tenantId}/resource-metadata-keys")
+  public ResponseEntity<?> getResourceMetadataKeys(ProxyExchange<?> proxy,
+                                                   @PathVariable String tenantId) {
+    final String backendUri = UriComponentsBuilder
+        .fromUriString(servicesProperties.getResourceManagementUrl())
+        .path("/api/tenant/{tenantId}/resource-metadata-keys")
+        .build(tenantId)
+        .toString();
+
+    return proxy.uri(backendUri).get();
+  }
+
+  @GetMapping("/tenant/{tenantId}/resource-label-namespaces")
+  public ResponseEntity<?> getLabelNamespaces(ProxyExchange<?> proxy,
+                                              @PathVariable String tenantId) {
+    final String backendUri = UriComponentsBuilder
+        .fromUriString(servicesProperties.getResourceManagementUrl())
+        .path("/api/tenant/{tenantId}/resource-label-namespaces")
+        .build(tenantId)
+        .toString();
+
+    return proxy.uri(backendUri).get();
+  }
+
   @PostMapping("/tenant/{tenantId}/resources")
   public ResponseEntity<?> create(ProxyExchange<?> proxy, @PathVariable String tenantId) {
     final String backendUri = UriComponentsBuilder


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-450

# What

Proxy the new APIs added to MM and RM:
- https://github.com/racker/salus-telemetry-monitor-management/pull/61
- https://github.com/racker/salus-telemetry-resource-management/pull/43