### PR TITLE
Fix admin api auth for dev

### DIFF
--- a/admin/src/main/resources/application-dev.yml
+++ b/admin/src/main/resources/application-dev.yml
@@ -11,4 +11,4 @@ services:
   agent-catalog-management-url: http://localhost:8090
 spring:
   profiles:
-    active: unsecured
+    include: unsecured


### PR DESCRIPTION
I fixed this on the public api before, but missed it on the admin.

This means that if you specify the `dev` profile it will automatically pull in the `unsecured` profile as well.