### PR TITLE
Update servlet context path to use salus prefixed property

### DIFF
--- a/public/src/main/resources/application.yml
+++ b/public/src/main/resources/application.yml
@@ -21,4 +21,4 @@ management:
         enabled: ${influx.enabled:false}
 server:
   servlet:
-    context-path: "/v${api.public.version}"
+    context-path: "/v${salus.api.public.version}"


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-461

# What

Follow up to https://github.com/racker/salus-telemetry-api/pull/46 that fixes the servlet context path to use the `salus.` prefixed property. Without this I was getting a 404 accessing expected paths and noticed this in the startup log

```
2019-07-22 14:45:22.364  INFO 93096 --- [           main] o.s.b.web.embedded.jetty.JettyWebServer  : Jetty started on port(s) 8080 (http/1.1) with context path '/v${api.public.version}'
```