### PR TITLE
Added proxy of test-monitor operation

### DIFF
--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/TestMonitorController.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/TestMonitorController.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.api.web;
+
+import com.rackspace.salus.telemetry.api.config.ServicesProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.gateway.mvc.ProxyExchange;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@RestController
+public class TestMonitorController {
+
+  private final ServicesProperties servicesProperties;
+
+  @Autowired
+  public TestMonitorController(ServicesProperties servicesProperties) {
+    this.servicesProperties = servicesProperties;
+  }
+
+  @PostMapping("/tenant/{tenantId}/test-monitor")
+  public ResponseEntity<?> create(ProxyExchange<?> proxy, @PathVariable String tenantId) {
+    final String backendUri = UriComponentsBuilder
+        .fromUriString(servicesProperties.getMonitorManagementUrl())
+        .path("/api/tenant/{tenantId}/test-monitor")
+        .build(tenantId)
+        .toString();
+
+    return proxy.uri(backendUri)
+        .post();
+  }
+}


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-564

# What

Adds a proxy of the POST test-monitor operation added to monitor-management in https://github.com/racker/salus-telemetry-monitor-management/pull/71