### PR TITLE
Add create, update, delete policy monitor endpoints

### DIFF
--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorPolicyController.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorPolicyController.java
@@ -27,6 +27,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -73,6 +74,44 @@ public class MonitorPolicyController {
     return proxy.uri(backendUri).get();
   }
 
+  @PostMapping("/policy-monitors")
+  public ResponseEntity<?> createPolicyMonitor(ProxyExchange<?> proxy) {
+
+    final String backendUri = UriComponentsBuilder
+        .fromUriString(servicesProperties.getMonitorManagementUrl())
+        .path("/api/admin/policy-monitors")
+        .build()
+        .toString();
+
+    return proxy.uri(backendUri).post();
+  }
+
+  @PutMapping("/policy-monitors/{uuid}")
+  public ResponseEntity<?> updatePolicyMonitor(ProxyExchange<?> proxy,
+      @PathVariable UUID uuid) {
+
+    final String backendUri = UriComponentsBuilder
+        .fromUriString(servicesProperties.getMonitorManagementUrl())
+        .path("/api/admin/policy-monitors/{uuid}")
+        .build(uuid)
+        .toString();
+
+    return proxy.uri(backendUri).put();
+  }
+
+  @DeleteMapping("/policy-monitors/{uuid}")
+  public ResponseEntity<?> deletePolicyMonitor(ProxyExchange<?> proxy,
+      @PathVariable UUID uuid) {
+
+    final String backendUri = UriComponentsBuilder
+        .fromUriString(servicesProperties.getMonitorManagementUrl())
+        .path("/api/admin/policy-monitors/{uuid}")
+        .build(uuid)
+        .toString();
+
+    return proxy.uri(backendUri).delete();
+  }
+
   @GetMapping("/policies/monitors")
   public ResponseEntity<?> getAllMonitorPolicies(ProxyExchange<?> proxy,
       @RequestParam MultiValueMap<String,String> queryParams) {
@@ -103,7 +142,7 @@ public class MonitorPolicyController {
   }
 
   @PostMapping("/policies/monitors")
-  public ResponseEntity<?> create(ProxyExchange<?> proxy) {
+  public ResponseEntity<?> createPolicy(ProxyExchange<?> proxy) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getPolicyManagementUrl())
         .path("/api/admin/policy/monitors")
@@ -115,7 +154,7 @@ public class MonitorPolicyController {
   }
 
   @DeleteMapping("/policies/monitors/{uuid}")
-  public ResponseEntity<?> delete(ProxyExchange<?> proxy,
+  public ResponseEntity<?> deletePolicy(ProxyExchange<?> proxy,
       @PathVariable UUID uuid) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())


### PR DESCRIPTION
# What

Adds the admin api endpoints to create, update, or delete policy monitors.

# Why

Forgot to include these in the last PR and noticed while trying to use them in Insomnia.