### PR TITLE
added RestExceptionHandler for handling certain 500 errors

### DIFF
--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/RestExceptionHandler.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/RestExceptionHandler.java
@@ -1,0 +1,27 @@
+package com.rackspace.salus.telemetry.api.web;
+
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.client.ResourceAccessException;
+
+@ControllerAdvice(basePackages = "com.rackspace.salus.telemetry.api.web")
+@ResponseBody
+public class RestExceptionHandler extends com.rackspace.salus.common.web.AbstractRestExceptionHandler {
+  @Autowired
+  public RestExceptionHandler(ErrorAttributes errorAttributes) {
+      super(errorAttributes);
+  }
+
+  @ExceptionHandler({ResourceAccessException.class})
+  public ResponseEntity<?> handleBadRequest(
+      HttpServletRequest request) {
+    return respondWith(request, HttpStatus.INTERNAL_SERVER_ERROR, "The API is currently experiencing a problem. Please try again in a few minutes.");
+  }
+
+}

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/RestExceptionHandler.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/RestExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.rackspace.salus.telemetry.api.web;
 
+import com.rackspace.salus.common.errors.ResponseMessages;
 import javax.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.servlet.error.ErrorAttributes;
@@ -21,7 +22,7 @@ public class RestExceptionHandler extends com.rackspace.salus.common.web.Abstrac
   @ExceptionHandler({ResourceAccessException.class})
   public ResponseEntity<?> handleBadRequest(
       HttpServletRequest request) {
-    return respondWith(request, HttpStatus.INTERNAL_SERVER_ERROR, "The API is currently experiencing a problem. Please try again in a few minutes.");
+    return respondWith(request, HttpStatus.BAD_GATEWAY, ResponseMessages.apiResourceAccessException);
   }
 
 }


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-433

# What

This PR is trying to catch the error when the API nodes are up but a service behind the API node isn't. 

# How

I am catching the particular error that gets thrown when another service isn't running. 

## How to test

Start the API, do not start the other services and make requests against the API

# Why

For unknown reasons Spring Boot doesn't seem to appreciate using the configuration options for not including the exception or the stack trace.

Instead I decided to utilize the pattern we are already using for catching exceptions and responding with HTTP status codes to give a friendly message.

# TODO

For each other service test when connections fail to any of the different services we need to communicate with (MySQL, Kafka, other microservices, etcd)