### PR TITLE
Add getOne methods

### DIFF
--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/EventTasksController.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/EventTasksController.java
@@ -60,8 +60,21 @@ public class EventTasksController {
     return proxy.uri(backendUri).get();
   }
 
-  @DeleteMapping("/tenant/{tenantId}/event-tasks/{taskId}")
+  @GetMapping("/tenant/{tenantId}/event-tasks/{taskId}")
   public ResponseEntity<?> getOne(ProxyExchange<?> proxy,
+      @PathVariable String tenantId,
+      @PathVariable String taskId) {
+    final String backendUri = UriComponentsBuilder
+        .fromUriString(servicesProperties.getEventManagementUrl())
+        .path("/api/tenant/{tenantId}/tasks/{taskId}")
+        .build(tenantId, taskId)
+        .toString();
+
+    return proxy.uri(backendUri).get();
+  }
+
+  @DeleteMapping("/tenant/{tenantId}/event-tasks/{taskId}")
+  public ResponseEntity<?> delete(ProxyExchange<?> proxy,
                                   @PathVariable String tenantId,
                                   @PathVariable String taskId) {
     final String backendUri = UriComponentsBuilder
@@ -71,6 +84,5 @@ public class EventTasksController {
         .toString();
 
     return proxy.uri(backendUri).delete();
-
   }
 }

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorsController.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorsController.java
@@ -57,6 +57,19 @@ public class MonitorsController {
     return proxy.uri(backendUri).get();
   }
 
+  @GetMapping("/tenant/{tenantId}/monitors/{id}")
+  public ResponseEntity<?> get(ProxyExchange<?> proxy,
+      @PathVariable String tenantId,
+      @PathVariable String id) {
+    final String backendUri = UriComponentsBuilder
+        .fromUriString(servicesProperties.getMonitorManagementUrl())
+        .path("/api/tenant/{tenantId}/monitors/{uuid}")
+        .build(tenantId, id)
+        .toString();
+
+    return proxy.uri(backendUri).get();
+  }
+
   @PostMapping("/tenant/{tenantId}/monitors")
   public ResponseEntity<?> create(ProxyExchange<?> proxy, @PathVariable String tenantId) {
     final String backendUri = UriComponentsBuilder

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/ResourcesController.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/ResourcesController.java
@@ -60,6 +60,21 @@ public class ResourcesController {
     return proxy.uri(backendUri).get();
   }
 
+  @GetMapping("/tenant/{tenantId}/resources/{resourceId}")
+  public ResponseEntity<?> getOne(ProxyExchange<?> proxy,
+      @PathVariable String tenantId,
+      @PathVariable String resourceId) {
+
+    final String backendUri = UriComponentsBuilder
+        .fromUriString(servicesProperties.getResourceManagementUrl())
+        .path("/api/tenant/{tenantId}/resources/{resourceId}")
+        .build(tenantId, resourceId)
+        .toString();
+
+    return proxy.uri(backendUri).get();
+  }
+
+
   @GetMapping("/tenant/{tenantId}/resources-by-label")
   public ResponseEntity<?> getResourcesWithLabels(ProxyExchange<?> proxy,
                                                   @PathVariable String tenantId,


### PR DESCRIPTION
# What

Adds ability to get monitor/task/resource by id.

# Why

Because.

# TODO

MonMgmt doesn't have a get bound monitor by id endpoint.  We may want to add that.