### PR TITLE
Add Spring Cloud Sleuth for web request log based tracing

### DIFF
--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -30,10 +30,6 @@
         <relativePath>../../salus-app-base</relativePath>
     </parent>
 
-    <properties>
-        <spring-cloud.version>Greenwich.SR1</spring-cloud.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -69,6 +65,10 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-gateway-mvc</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-sleuth</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.rackspace.salus</groupId>
@@ -102,18 +102,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.springframework.cloud</groupId>
-                <artifactId>spring-cloud-dependencies</artifactId>
-                <version>${spring-cloud.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <build>
         <plugins>

--- a/admin/src/main/resources/bootstrap.yml
+++ b/admin/src/main/resources/bootstrap.yml
@@ -1,0 +1,3 @@
+spring:
+  application:
+    name: salus-api-admin

--- a/admin/src/main/resources/logback-spring.xml
+++ b/admin/src/main/resources/logback-spring.xml
@@ -24,19 +24,12 @@
     <include resource="logback-fluency.xml" />
   </springProfile>
 
-  
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <encoder>
-      <pattern><![CDATA[%date{HH:mm:ss.SSS} [%thread] %-5level %logger{15}#%line %msg%n]]></pattern>
-    </encoder>
-  </appender>
-
   <root level="INFO">
     <springProfile name="production">
       <appender-ref ref="FLUENCY" />
     </springProfile>
     <springProfile name="!production">
-      <appender-ref ref="STDOUT"/>
+      <appender-ref ref="CONSOLE"/>
     </springProfile>
   </root>
 

--- a/public/pom.xml
+++ b/public/pom.xml
@@ -30,10 +30,6 @@
         <relativePath>../../salus-app-base</relativePath>
     </parent>
 
-    <properties>
-        <spring-cloud.version>Greenwich.SR1</spring-cloud.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -64,6 +60,10 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-gateway-mvc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-sleuth</artifactId>
         </dependency>
         <dependency>
             <groupId>com.rackspace.salus</groupId>
@@ -102,18 +102,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.springframework.cloud</groupId>
-                <artifactId>spring-cloud-dependencies</artifactId>
-                <version>${spring-cloud.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <build>
         <plugins>

--- a/public/src/main/resources/bootstrap.yml
+++ b/public/src/main/resources/bootstrap.yml
@@ -1,0 +1,3 @@
+spring:
+  application:
+    name: salus-api-public

--- a/public/src/main/resources/logback-spring.xml
+++ b/public/src/main/resources/logback-spring.xml
@@ -24,19 +24,12 @@
     <include resource="logback-fluency.xml" />
   </springProfile>
 
-  
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <encoder>
-      <pattern><![CDATA[%date{HH:mm:ss.SSS} [%thread] %-5level %logger{15}#%line %msg%n]]></pattern>
-    </encoder>
-  </appender>
-
   <root level="INFO">
     <springProfile name="production">
       <appender-ref ref="FLUENCY" />
     </springProfile>
     <springProfile name="!production">
-      <appender-ref ref="STDOUT"/>
+      <appender-ref ref="CONSOLE"/>
     </springProfile>
   </root>
 


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-648

# What

Even though we have shifted some "inter service" interactions to shared DB access, we still have a few, but critical. inter-service REST calls where it will get harder to debug those end to end operations when in production.

# How

We have only scratched the surface of Spring Cloud with our use of its gateway function in our api-public and api-admin apps...Sleuth is a part of that suite that provides a very customizable request tracing facility. By default, it does log based tracing, which is a great start for us. Later we can leverage its Zipkin integration, etc to regain some visibility lost when we paused on Istio.

The changes involved:
- adding the sleuth dependencies, which triggers auto config and reasonable defaults
- shifting the `spring.application.name` declaration to `bootstrap.yml` since that is where the Sleuth logging (along with most Spring Cloud facilities) requires that to be declared
- using the builtin `CONSOLE` appender declaration since its logging pattern gets automatically injected with the Sleuth MDC parameters

# Example

The Sleuth logging adds a `[appname,traceId,spanId,exportable]` field just after the severity, where:

- spanId: The ID of a specific operation that took place.
- appname: The name of the application that logged the span.
- traceId: The ID of the latency graph that contains the span.
- exportable: Whether the log should be exported to Zipkin. When would you like the span not to be exportable? When you want to wrap some operation in a Span and have it written to the logs only.

The following shows some log snippets for a create monitor call that got a trace ID of `dcedd973158780de` assigned. 

### Public API

```
2019-10-10 10:19:59.287 DEBUG [salus-api-public,dcedd973158780de,dcedd973158780de,false] 50857 --- [tp1146867354-35] o.s.web.servlet.DispatcherServlet        : POST "/v1.0/tenant/aaaaaa/monitors", parameters={}
2019-10-10 10:19:59.294 DEBUG [salus-api-public,dcedd973158780de,dcedd973158780de,false] 50857 --- [tp1146867354-35] o.s.web.client.RestTemplate              : HTTP POST http://localhost:8089/api/tenant/aaaaaa/monitors
2019-10-10 10:20:00.962 DEBUG [salus-api-public,dcedd973158780de,dcedd973158780de,false] 50857 --- [tp1146867354-35] o.s.web.servlet.DispatcherServlet        : Completed 201 CREATED
```

### Monitor Management

```
2019-10-10 10:19:59.372 DEBUG [salus-telemetry-monitor-management,dcedd973158780de,bb2e79e5a0ab8923,false] 51422 --- [nio-8089-exec-1] o.s.web.servlet.DispatcherServlet        : POST "/api/tenant/aaaaaa/monitors", parameters={}
2019-10-10 10:19:59.565 DEBUG [salus-telemetry-monitor-management,dcedd973158780de,bb2e79e5a0ab8923,false] 51422 --- [nio-8089-exec-1] o.s.web.client.RestTemplate              : HTTP GET http://localhost:8091/api/admin/policy/metadata/monitor/effective/aaaaaa/LocalPlugin/net
2019-10-10 10:19:59.752 DEBUG [salus-telemetry-monitor-management,dcedd973158780de,bb2e79e5a0ab8923,false] 51422 --- [nio-8089-exec-1] o.s.web.client.RestTemplate              : Response 200 OK
2019-10-10 10:19:59.765 DEBUG [salus-telemetry-monitor-management,dcedd973158780de,bb2e79e5a0ab8923,false] 51422 --- [nio-8089-exec-1] c.r.s.m.utils.MetadataUtils              : Setting policy metadata on 1 fields for tenant aaaaaa
2019-10-10 10:19:59.773 DEBUG [salus-telemetry-monitor-management,dcedd973158780de,bb2e79e5a0ab8923,false] 51422 --- [nio-8089-exec-1] c.r.s.m.services.MonitorManagement       : Creating monitor=MonitorCU(monitorName=Network Stats, labelSelector={agent_discovered_os=linux}, labelSelectorMethod=AND, content={"type":"net","interfaces":null,"ignoreProtocolStats":true}, monitorType=net, agentType=TELEGRAF, selectorScope=LOCAL, zones=null, resourceId=null, interval=PT1M, pluginMetadataFields=[interfaces]) for tenant=aaaaaa
2019-10-10 10:19:59.784 DEBUG [salus-telemetry-monitor-management,dcedd973158780de,bb2e79e5a0ab8923,false] 51422 --- [nio-8089-exec-1] o.s.web.client.RestTemplate              : HTTP GET http://localhost:8091/api/admin/policy/metadata/monitor/effective/aaaaaa/Monitor/net
2019-10-10 10:19:59.798 DEBUG [salus-telemetry-monitor-management,dcedd973158780de,bb2e79e5a0ab8923,false] 51422 --- [nio-8089-exec-1] o.s.web.client.RestTemplate              : Response 200 OK
2019-10-10 10:19:59.893 DEBUG [salus-telemetry-monitor-management,dcedd973158780de,bb2e79e5a0ab8923,false] 51422 --- [nio-8089-exec-1] o.s.web.client.RestTemplate              : HTTP GET http://localhost:8085/api/admin/resources-by-label/aaaaaa/AND?agent_discovered_os=linux
2019-10-10 10:20:00.870 DEBUG [salus-telemetry-monitor-management,dcedd973158780de,bb2e79e5a0ab8923,false] 51422 --- [nio-8089-exec-1] o.s.web.client.RestTemplate              : Response 200 OK
2019-10-10 10:20:00.885 DEBUG [salus-telemetry-monitor-management,dcedd973158780de,bb2e79e5a0ab8923,false] 51422 --- [nio-8089-exec-1] c.r.s.m.services.MonitorManagement       : Distributing new monitor=id=fff4e846-6238-4ea9-8f0a-05f41b47b5a4, name=Network Stats, tenantId=aaaaaa, monitorType=net, resourceId=null, selectorScope=LOCAL, labelSelector={agent_discovered_os=linux}, labelSelectorMethod=AND, zones=null, interval=PT1M to resources=[]
2019-10-10 10:20:00.909 DEBUG [salus-telemetry-monitor-management,dcedd973158780de,bb2e79e5a0ab8923,false] 51422 --- [nio-8089-exec-1] o.s.web.servlet.DispatcherServlet        : Completed 201 CREATED
```

### Policy Management

```
2019-10-10 10:19:59.642 DEBUG [salus-policy-management,dcedd973158780de,937102ca6f997d24,false] 51335 --- [nio-8091-exec-1] o.s.web.servlet.DispatcherServlet        : GET "/api/admin/policy/metadata/monitor/effective/aaaaaa/LocalPlugin/net", parameters={}
2019-10-10 10:19:59.752 DEBUG [salus-policy-management,dcedd973158780de,937102ca6f997d24,false] 51335 --- [nio-8091-exec-1] o.s.web.servlet.DispatcherServlet        : Completed 200 OK
```

### Resource Management

```
2019-10-10 10:20:00.657 DEBUG [salus-telemetry-resource-management,dcedd973158780de,318ca34389584f5c,false] 50861 --- [nio-8085-exec-1] o.s.web.servlet.DispatcherServlet        : GET "/api/admin/resources-by-label/aaaaaa/AND?agent_discovered_os=linux", parameters={agent_discovered_os:[linux]}
2019-10-10 10:20:00.871 DEBUG [salus-telemetry-resource-management,dcedd973158780de,318ca34389584f5c,false] 50861 --- [nio-8085-exec-1] o.s.web.servlet.DispatcherServlet        : Completed 200 OK
```

# How to test

Manually with api-public, MM, RM, and PM running.

# Depends on

- https://github.com/racker/salus-app-base/pull/18