### PR TITLE
Use correct service endpoint when deleting policy

### DIFF
--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorPolicyController.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorPolicyController.java
@@ -157,7 +157,7 @@ public class MonitorPolicyController {
   public ResponseEntity<?> deletePolicy(ProxyExchange<?> proxy,
       @PathVariable UUID uuid) {
     final String backendUri = UriComponentsBuilder
-        .fromUriString(servicesProperties.getMonitorManagementUrl())
+        .fromUriString(servicesProperties.getPolicyManagementUrl())
         .path("/api/admin/policy/monitors/{uuid}")
         .build(uuid)
         .toString();


### PR DESCRIPTION
Should fix this - https://gist.github.com/GeorgeJahad/6bcb52f93aa075c1ddd26029fab07e2c

To delete a Monitor used in a Policy you would hit monitor management, but to delete the actual policy it needs to hit Policy Mgmt.