### PR TITLE
Allow query params in the tasks api

### DIFF
--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/EventTasksController.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/EventTasksController.java
@@ -20,10 +20,12 @@ import com.rackspace.salus.telemetry.api.config.ServicesProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.mvc.ProxyExchange;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -50,10 +52,13 @@ public class EventTasksController {
   }
 
   @GetMapping("/tenant/{tenantId}/event-tasks")
-  public ResponseEntity<?> getAll(ProxyExchange<?> proxy, @PathVariable String tenantId) {
+  public ResponseEntity<?> getAll(ProxyExchange<?> proxy,
+                                  @PathVariable String tenantId,
+                                  @RequestParam MultiValueMap<String,String> queryParams) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getEventManagementUrl())
         .path("/api/tenant/{tenantId}/tasks")
+        .queryParams(queryParams)
         .build(tenantId)
         .toString();
 


### PR DESCRIPTION
@GeorgeJahad noticed the Task API was not acting properly when being passed something like `?page=3` when getting a list of tasks.  This should solve that.