### PR TITLE
Include Sleuth trace ID in response headers/attributes

### DIFF
--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/config/TracingErrorAttributesConfig.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/config/TracingErrorAttributesConfig.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.api.config;
+
+import brave.Span;
+import brave.Tracer;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.servlet.error.DefaultErrorAttributes;
+import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.request.WebRequest;
+
+@Configuration
+@EnableConfigurationProperties({ServerProperties.class})
+public class TracingErrorAttributesConfig {
+
+  private static final String ATTRIBUTE_TRACE_ID = "traceId";
+  private static final String ATTRIBUTE_APP = "app";
+  private static final String ATTRIBUTE_HOST = "host";
+
+  /**
+   * Registers an extension of the standard Spring Boot {@link ErrorAttributes}
+   * that complements the {@link com.rackspace.salus.telemetry.api.web.TraceResponseFilter} by
+   * providing extended information for errors that originate at this proxy layer, such as failure
+   * to contact a backend service.
+   * <p>
+   * The Spring Cloud Sleuth Trace ID is populated into the attribute {@value #ATTRIBUTE_TRACE_ID}
+   * along with the attributes {@value #ATTRIBUTE_APP} and {@value #ATTRIBUTE_HOST}, similar to
+   * {@link com.rackspace.salus.common.web.ExtendedErrorAttributesConfig#errorAttributes(ServerProperties, String, String)}
+   * </p>
+   */
+  @Bean
+  public ErrorAttributes errorAttributes(ServerProperties serverProperties,
+                                         @Value("${spring.application.name}") String appName,
+                                         @Value("${localhost.name}") String ourHost,
+                                         Tracer tracer) {
+    return new DefaultErrorAttributes(serverProperties.getError().isIncludeException()) {
+      @Override
+      public Map<String, Object> getErrorAttributes(WebRequest webRequest,
+                                                    boolean includeStackTrace) {
+        final Map<String, Object> errorAttributes = super
+            .getErrorAttributes(webRequest, includeStackTrace);
+
+        errorAttributes.put(ATTRIBUTE_APP, appName);
+        errorAttributes.put(ATTRIBUTE_HOST, ourHost);
+
+        final Span currentSpan = tracer.currentSpan();
+        if (currentSpan != null) {
+          errorAttributes.put(ATTRIBUTE_TRACE_ID, currentSpan.context().traceIdString());
+        }
+
+        return errorAttributes;
+      }
+    };
+  }
+
+}

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/web/RestExceptionHandler.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/web/RestExceptionHandler.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.api.web;
+
+import com.rackspace.salus.common.web.AbstractRestExceptionHandler;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.util.NestedServletException;
+
+@ControllerAdvice(basePackageClasses = {RestExceptionHandler.class})
+@ResponseBody
+public class RestExceptionHandler extends AbstractRestExceptionHandler {
+
+  @Autowired
+  public RestExceptionHandler(ErrorAttributes errorAttributes) {
+    super(errorAttributes);
+  }
+
+  /**
+   * Ensures that a {@link ResourceAccessException} that causes a {@link NestedServletException}
+   * is properly converted into a 502 status externally.
+   */
+  @ExceptionHandler({NestedServletException.class})
+  public ResponseEntity<?> handleNotFound(
+      HttpServletRequest request, Exception e) {
+    logRequestFailure(request, e);
+
+    return respondWith(request,
+        e.getCause() instanceof ResourceAccessException ?
+            HttpStatus.BAD_GATEWAY : HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+}

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/web/RestExceptionHandler.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/web/RestExceptionHandler.java
@@ -42,7 +42,7 @@ public class RestExceptionHandler extends AbstractRestExceptionHandler {
    * is properly converted into a 502 status externally.
    */
   @ExceptionHandler({NestedServletException.class})
-  public ResponseEntity<?> handleNotFound(
+  public ResponseEntity<?> handleNestedServletException(
       HttpServletRequest request, Exception e) {
     logRequestFailure(request, e);
 

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/web/TraceResponseFilter.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/web/TraceResponseFilter.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.api.web;
+
+import brave.Span;
+import brave.Tracer;
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.sleuth.instrument.web.TraceWebServletAutoConfiguration;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.GenericFilterBean;
+
+/**
+ * This filter populates all non-error responses with the header {@value #HEADER_TRACE_ID} set to
+ * the Spring Cloud Sleuth Trace ID of the overall request.
+ * <p>
+ *   The majority of this code was derived from the
+ *   <a href="https://cloud.spring.io/spring-cloud-sleuth/reference/html/index.html#tracingfilter">Spring Cloud Sleuth documentation.</a>
+ * </p>
+ */
+@Component
+@Order(TraceWebServletAutoConfiguration.TRACING_FILTER_ORDER+1)
+public class TraceResponseFilter extends GenericFilterBean {
+
+  private static final String HEADER_TRACE_ID = "X-Trace-Id";
+
+  private final Tracer tracer;
+
+  @Autowired
+  public TraceResponseFilter(Tracer tracer) {
+    this.tracer = tracer;
+  }
+
+  @Override
+  public void doFilter(ServletRequest req, ServletResponse resp,
+                       FilterChain chain) throws IOException, ServletException {
+    final Span currentSpan = tracer.currentSpan();
+    if (currentSpan == null) {
+      chain.doFilter(req, resp);
+      return;
+    }
+
+    ((HttpServletResponse) resp).addHeader(HEADER_TRACE_ID, currentSpan.context().traceIdString());
+
+    chain.doFilter(req, resp);
+  }
+}

--- a/admin/src/main/resources/logback-fluency.xml
+++ b/admin/src/main/resources/logback-fluency.xml
@@ -35,7 +35,7 @@
     <port>${SALUS_FLUENTD_PORT}</port>
 
     <encoder>
-      <pattern><![CDATA[%date{HH:mm:ss.SSS} [%thread] %-5level %logger{15}#%line %msg]]></pattern>
+      <pattern>${FILE_LOG_PATTERN}</pattern>
     </encoder>
   </appender>
 

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/config/TracingErrorAttributesConfig.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/config/TracingErrorAttributesConfig.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.api.config;
+
+import brave.Span;
+import brave.Tracer;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.servlet.error.DefaultErrorAttributes;
+import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.request.WebRequest;
+
+@Configuration
+@EnableConfigurationProperties({ServerProperties.class})
+public class TracingErrorAttributesConfig {
+
+  private static final String ATTRIBUTE_TRACE_ID = "traceId";
+  private static final String ATTRIBUTE_APP = "app";
+  private static final String ATTRIBUTE_HOST = "host";
+
+  /**
+   * Registers an extension of the standard Spring Boot {@link ErrorAttributes}
+   * that complements the {@link com.rackspace.salus.telemetry.api.web.TraceResponseFilter} by
+   * providing extended information for errors that originate at this proxy layer, such as failure
+   * to contact a backend service.
+   * <p>
+   * The Spring Cloud Sleuth Trace ID is populated into the attribute {@value #ATTRIBUTE_TRACE_ID}
+   * along with the attributes {@value #ATTRIBUTE_APP} and {@value #ATTRIBUTE_HOST}, similar to
+   * {@link com.rackspace.salus.common.web.ExtendedErrorAttributesConfig#errorAttributes(ServerProperties, String, String)}
+   * </p>
+   */
+  @Bean
+  public ErrorAttributes errorAttributes(ServerProperties serverProperties,
+                                         @Value("${spring.application.name}") String appName,
+                                         @Value("${localhost.name}") String ourHost,
+                                         Tracer tracer) {
+    return new DefaultErrorAttributes(serverProperties.getError().isIncludeException()) {
+      @Override
+      public Map<String, Object> getErrorAttributes(WebRequest webRequest,
+                                                    boolean includeStackTrace) {
+        final Map<String, Object> errorAttributes = super
+            .getErrorAttributes(webRequest, includeStackTrace);
+
+        errorAttributes.put(ATTRIBUTE_APP, appName);
+        errorAttributes.put(ATTRIBUTE_HOST, ourHost);
+
+        final Span currentSpan = tracer.currentSpan();
+        if (currentSpan != null) {
+          errorAttributes.put(ATTRIBUTE_TRACE_ID, currentSpan.context().traceIdString());
+        }
+
+        return errorAttributes;
+      }
+    };
+  }
+
+}

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/RestExceptionHandler.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/RestExceptionHandler.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.api.web;
+
+import com.rackspace.salus.common.web.AbstractRestExceptionHandler;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.util.NestedServletException;
+
+@ControllerAdvice(basePackageClasses = {RestExceptionHandler.class})
+@ResponseBody
+public class RestExceptionHandler extends AbstractRestExceptionHandler {
+
+  @Autowired
+  public RestExceptionHandler(ErrorAttributes errorAttributes) {
+    super(errorAttributes);
+  }
+
+  /**
+   * Ensures that a {@link ResourceAccessException} that causes a {@link NestedServletException}
+   * is properly converted into a 502 status externally.
+   */
+  @ExceptionHandler({NestedServletException.class})
+  public ResponseEntity<?> handleNotFound(
+      HttpServletRequest request, Exception e) {
+    logRequestFailure(request, e);
+
+    return respondWith(request,
+        e.getCause() instanceof ResourceAccessException ?
+            HttpStatus.BAD_GATEWAY : HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+}

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/RestExceptionHandler.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/RestExceptionHandler.java
@@ -42,7 +42,7 @@ public class RestExceptionHandler extends AbstractRestExceptionHandler {
    * is properly converted into a 502 status externally.
    */
   @ExceptionHandler({NestedServletException.class})
-  public ResponseEntity<?> handleNotFound(
+  public ResponseEntity<?> handleNestedServletException(
       HttpServletRequest request, Exception e) {
     logRequestFailure(request, e);
 

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/TraceResponseFilter.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/TraceResponseFilter.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.api.web;
+
+import brave.Span;
+import brave.Tracer;
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.sleuth.instrument.web.TraceWebServletAutoConfiguration;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.GenericFilterBean;
+
+/**
+ * This filter populates all non-error responses with the header {@value #HEADER_TRACE_ID} set to
+ * the Spring Cloud Sleuth Trace ID of the overall request.
+ * <p>
+ *   The majority of this code was derived from the
+ *   <a href="https://cloud.spring.io/spring-cloud-sleuth/reference/html/index.html#tracingfilter">Spring Cloud Sleuth documentation.</a>
+ * </p>
+ */
+@Component
+@Order(TraceWebServletAutoConfiguration.TRACING_FILTER_ORDER+1)
+public class TraceResponseFilter extends GenericFilterBean {
+
+  private static final String HEADER_TRACE_ID = "X-Trace-Id";
+
+  private final Tracer tracer;
+
+  @Autowired
+  public TraceResponseFilter(Tracer tracer) {
+    this.tracer = tracer;
+  }
+
+  @Override
+  public void doFilter(ServletRequest req, ServletResponse resp,
+                       FilterChain chain) throws IOException, ServletException {
+    final Span currentSpan = tracer.currentSpan();
+    if (currentSpan == null) {
+      chain.doFilter(req, resp);
+      return;
+    }
+
+    ((HttpServletResponse) resp).addHeader(HEADER_TRACE_ID, currentSpan.context().traceIdString());
+
+    chain.doFilter(req, resp);
+  }
+}

--- a/public/src/main/resources/logback-fluency.xml
+++ b/public/src/main/resources/logback-fluency.xml
@@ -35,7 +35,7 @@
     <port>${SALUS_FLUENTD_PORT}</port>
 
     <encoder>
-      <pattern><![CDATA[%date{HH:mm:ss.SSS} [%thread] %-5level %logger{15}#%line %msg]]></pattern>
+      <pattern>${FILE_LOG_PATTERN}</pattern>
     </encoder>
   </appender>
 


### PR DESCRIPTION
# Resolves

Follow up to https://github.com/racker/salus-telemetry-api/pull/58

# What

I had some loose ends locally modified from the Spring Cloud Sleuth changes that I was able to finish up. I wanted to have a way for the sleuth trace ID to get propagated out via the response so when a user reports an API issue we can request the trace ID and then locate the end to end logs using that.

I also noticed cases where the backend service was unreachable were resulting in a generic 500 type response.

# How

Added our usual REST exception handler for the resource access exceptions, but had to intercept the outer exception I had located in logs prior to the change.

Added a filter that gets invoked after Sleuth to grab the trace ID from the current span and add a response header. I pretty much copy-pasted the docs solution.

Errors that originate in the api-public/admin layer didn't flow as nicely through that filter. Instead they do a weird internal direct to the "error page" handling, which defeated the normal filter flow. My compromise was to use a similar error attributes extension as we do in the apps (supplied by salus-common), but also include the trace ID.

**NOTE** I had to duplicate the code in api-public and api-admin each since we don't yet have an `api-common` type module in place and doesn't quite seem worth it yet to have one. I'm open to suggestions though.

# How to test

The following show some snippets from the manual testing I did:

## Error scenario

Response

```json
{
  "timestamp": "2019-10-23T14:27:18.204+0000",
  "status": 502,
  "error": "Bad Gateway",
  "message": "I/O error on GET request for \"http://localhost:8089/api/tenant/646398/monitors\": Connection refused (Connection refused); nested exception is java.net.ConnectException: Connection refused (Connection refused)",
  "app": "salus-api-public",
  "host": "MS90HCG8WL",
  "traceId": "351c54f05a783c25"
}
```

Logs can be located by `traceId` of `351c54f05a783c25`:

```
2019-10-23 09:27:18.136 DEBUG [salus-api-public,351c54f05a783c25,351c54f05a783c25,false] 8774 --- [qtp866073173-36] o.s.web.servlet.DispatcherServlet        : GET "/v1.0/tenant/646398/monitors", parameters={}
2019-10-23 09:27:18.144 DEBUG [salus-api-public,351c54f05a783c25,351c54f05a783c25,false] 8774 --- [qtp866073173-36] s.w.s.m.m.a.RequestMappingHandlerMapping : Mapped to public org.springframework.http.ResponseEntity<?> com.rackspace.salus.telemetry.api.web.MonitorsController.getAll(org.springframework.cloud.gateway.mvc.ProxyExchange<?>,java.lang.String,org.springframework.util.MultiValueMap<java.lang.String, java.lang.String>)
2019-10-23 09:27:18.174 DEBUG [salus-api-public,351c54f05a783c25,351c54f05a783c25,false] 8774 --- [qtp866073173-36] o.s.web.client.RestTemplate              : HTTP GET http://localhost:8089/api/tenant/646398/monitors
2019-10-23 09:27:18.177 DEBUG [salus-api-public,351c54f05a783c25,351c54f05a783c25,false] 8774 --- [qtp866073173-36] o.s.web.client.RestTemplate              : Accept=[application/json, application/*+json]
2019-10-23 09:27:18.201 DEBUG [salus-api-public,351c54f05a783c25,351c54f05a783c25,false] 8774 --- [qtp866073173-36] .m.m.a.ExceptionHandlerExceptionResolver : Using @ExceptionHandler public org.springframework.http.ResponseEntity<?> com.rackspace.salus.common.web.AbstractRestExceptionHandler.handleRestClientException(javax.servlet.http.HttpServletRequest,org.springframework.web.client.RestClientException)
2019-10-23 09:27:18.203  WARN [salus-api-public,351c54f05a783c25,351c54f05a783c25,false] 8774 --- [qtp866073173-36] c.r.s.c.w.AbstractRestExceptionHandler   : Web request for uri=/v1.0/tenant/646398/monitors failed

org.springframework.web.client.ResourceAccessException: I/O error on GET request for "http://localhost:8089/api/tenant/646398/monitors": Connection refused (Connection refused); nested exception is java.net.ConnectException: Connection refused (Connection refused)
	at org.springframework.web.client.RestTemplate.doExecute(RestTemplate.java:744)
	at org.springframework.web.client.RestTemplate.exchange(RestTemplate.java:647)
	at org.springframework.cloud.gateway.mvc.ProxyExchange.exchange(ProxyExchange.java:352)
	at org.springframework.cloud.gateway.mvc.ProxyExchange.get(ProxyExchange.java:273)
	at com.rackspace.salus.telemetry.api.web.MonitorsController.getAll(MonitorsController.java:57)
  ... snip
Caused by: java.net.ConnectException: Connection refused (Connection refused)
	... snip
```


## Non-error scenario

Headers in response, note the `X-Trace-Id`
```
Date: Wed, 23 Oct 2019 15:08:16 GMT
X-Trace-Id: 2a23425a8e2414db
Date: Wed, 23 Oct 2019 15:08:16 GMT
Content-Type: application/json;charset=utf-8
X-Content-Type-Options: nosniff
X-XSS-Protection: 1; mode=block
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
Transfer-Encoding: chunked
```

Logs from api-public
```
2019-10-23 10:08:16.417 DEBUG [salus-api-public,2a23425a8e2414db,2a23425a8e2414db,false] 8774 --- [qtp866073173-36] o.s.web.servlet.DispatcherServlet        : GET "/v1.0/tenant/646398/monitors", parameters={}
```

Logs from monitor management
```
2019-10-23 10:08:16.568 DEBUG [salus-telemetry-monitor-management,2a23425a8e2414db,aa81a4c7e2730add,false] 12349 --- [nio-8089-exec-1] o.s.web.servlet.DispatcherServlet        : GET "/api/tenant/646398/monitors", parameters={}
```

# TODO

Look into adding the Spring Cloud Sleuth dependency into salus-common at which point the apps could also include the trace ID as an attribute.