### PR TITLE
Fix downstream path for resources update/PUT

### DIFF
--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/ResourcesController.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/ResourcesController.java
@@ -145,7 +145,7 @@ public class ResourcesController {
                                   @PathVariable String resourceId) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getResourceManagementUrl())
-        .path("/api/{tenantId}/resources/{resourceId}")
+        .path("/api/tenant/{tenantId}/resources/{resourceId}")
         .build(tenantId, resourceId)
         .toString();
 


### PR DESCRIPTION
# What

Update/PUT for resources was missing the `/tenant` part of the backend path. As a result, requests to the public API endpoint were always giving a 404.

cc @FarajiA 