### PR TITLE
Provide a web mvc interceptor that logs requests with the response status

### DIFF
--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -69,6 +69,10 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-sleuth</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-zipkin</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.rackspace.salus</groupId>

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/config/WebConfig.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/config/WebConfig.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.api.config;
+
+import com.rackspace.salus.common.web.RequestLogging;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(new RequestLogging());
+  }
+}

--- a/public/pom.xml
+++ b/public/pom.xml
@@ -66,6 +66,10 @@
             <artifactId>spring-cloud-starter-sleuth</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-zipkin</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.rackspace.salus</groupId>
             <artifactId>salus-telemetry-model</artifactId>
             <version>0.1.0-SNAPSHOT</version>

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/config/WebConfig.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/config/WebConfig.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.api.config;
+
+import com.rackspace.salus.common.web.RequestLogging;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(new RequestLogging());
+  }
+}


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-725

# What

We didn't have any existing log entries that included the request info, the response status, and the sleuth trace ID all together. As a result, it would have been hard to troubleshoot a specific request reported by one of our users and then pick out the logs associated with that trace.

# How

Based on [this article](https://www.baeldung.com/spring-http-logging), register a web mvc interceptor. It produces logs that look like:

```
2019-12-13 15:33:28.748  INFO [salus-api-public,da9caf57b709d1f7,da9caf57b709d1f7,true] 28541 --- [qtp284427775-36] c.r.salus.common.web.RequestLogging      : Request completed: method=GET path=/v1.0/tenant/aaaaaa/monitors parameters={} status=502

2019-12-13 15:34:46.722  INFO [salus-api-public,78ba9855342f098c,78ba9855342f098c,true] 28541 --- [qtp284427775-32] c.r.salus.common.web.RequestLogging      : Request completed: method=GET path=/v1.0/tenant/aaaaaa/resources parameters={page=[0]} status=200
```

Also includes the sleuth zipkin starter to allow for zipkin usage when that is deployed to our clusters.

# How to test

Manually by making a successful request against a backend that's running vs a request that can't reach a backend that is not running.

# Depends on

https://github.com/racker/salus-common/pull/44