### PR TITLE
Disable zipkin by default and log registration of RequestLogging

### DIFF
--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/config/WebConfig.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/config/WebConfig.java
@@ -17,15 +17,18 @@
 package com.rackspace.salus.telemetry.api.config;
 
 import com.rackspace.salus.common.web.RequestLogging;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@Slf4j
 public class WebConfig implements WebMvcConfigurer {
 
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
+    log.debug("Enabling RequestLogging interceptor");
     registry.addInterceptor(new RequestLogging());
   }
 }

--- a/admin/src/main/resources/application.yml
+++ b/admin/src/main/resources/application.yml
@@ -8,3 +8,6 @@ management:
         uri: ${salus.metrics.influx.uri:http://localhost:8086}
         db: salus
         enabled: ${salus.metrics.influx.enabled:false}
+spring:
+  zipkin:
+    enabled: false

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/config/WebConfig.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/config/WebConfig.java
@@ -17,15 +17,18 @@
 package com.rackspace.salus.telemetry.api.config;
 
 import com.rackspace.salus.common.web.RequestLogging;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@Slf4j
 public class WebConfig implements WebMvcConfigurer {
 
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
+    log.debug("Enabling RequestLogging interceptor");
     registry.addInterceptor(new RequestLogging());
   }
 }

--- a/public/src/main/resources/application.yml
+++ b/public/src/main/resources/application.yml
@@ -16,3 +16,6 @@ management:
 server:
   servlet:
     context-path: "/v${salus.api.public.version}"
+spring:
+  zipkin:
+    enabled: false


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-725

# What

With the zipkin dependency added it was getting auto-enabled. Since we don't yet have a zipkin endpoint deployed, we get warning logs like the following:

```
{
    "level": "WARN",
    "logger": "zipkin2.reporter.AsyncReporter$BoundedAsyncReporter",
    "host": "api-public-6c86fcf445-vqhzz",
    "thread": "AsyncReporter{org.springframework.cloud.sleuth.zipkin2.sender.RestTemplateSender@3c28181b}",
    "message": "Spans were dropped due to exceptions. All subsequent errors will be logged at FINE level.",
    "@timestamp": "2019-12-16T14:48:16.000000000+00:00",
    "tag": "application.salus-api-public"
  }
```

# How

The helm chart has now disabled zipkin, but I'm going to make this change in each of our REST API microservices as I add zipkin support, so I wanted to be consistent.