### PR TITLE
Add monitor PATCH proxy endpoint

### DIFF
--- a/public/pom.xml
+++ b/public/pom.xml
@@ -91,6 +91,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorsController.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorsController.java
@@ -17,14 +17,12 @@
 package com.rackspace.salus.telemetry.api.web;
 
 import com.rackspace.salus.telemetry.api.config.ServicesProperties;
-import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.mvc.ProxyExchange;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.util.MultiValueMap;

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorsController.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorsController.java
@@ -116,7 +116,7 @@ public class MonitorsController {
    * @return The String deserialization of the monitor.
    */
   @PatchMapping(path = "/tenant/{tenantId}/monitors/{id}",
-                consumes = {PATCH_MEDIA_TYPE_VALUE})
+                consumes = PATCH_MEDIA_TYPE_VALUE)
   public ResponseEntity<String> patch(@RequestHeader MultiValueMap<String, String> originalHeaders,
                                  @RequestBody String body,
                                  @PathVariable String tenantId,


### PR DESCRIPTION
# What

Adds an endpoint that proxies through to monitor management's 
```
  public DetailedMonitorOutput patch(@PathVariable String tenantId,
      @PathVariable UUID uuid,
      @RequestBody final JsonPatch input)
```

# How

We can not use `proxy.uri(backendUri).patch()` like everything else as it fails with `java.net.ProtocolException: Invalid HTTP method: PATCH`.

Instead I reconstruct the request and pass it on using RestTemplate - https://github.com/spring-cloud/spring-cloud-netflix/issues/1777#issuecomment-318293029

It feels like there should be a better way?  Being able to get the HttpEntity directly would be nicer.

This currently also excludes any request parameters but I think that's ok for this endpoint?  I don't think we'd ever need to handle any for this request.

## How to test

I've tested manually.

> Request completed: method=PATCH path=/v1.0/tenant/aaaaaa/monitors/804f4252-6b70-42e5-8475-c427e4605f0f parameters={} status=200

while passing this payload

```
[
	{ "op": "replace", "path": "/details/plugin/timeout", "value": 40 }
]
```
and specifying the `application/json-patch+json` content-type.  Any other content type will fail due to a 415.

# Why

We need to be able to hit this endpoint from the public api.

# TODO

Insomnia PR incoming.