### PR TITLE
Added endpoint for generating monitor plugins schema

### DIFF
--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorsController.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorsController.java
@@ -160,14 +160,12 @@ public class MonitorsController {
     return proxy.uri(backendUri).get();
   }
 
-  @GetMapping("/tenant/{tenantId}/monitor-plugins-schema")
-  public ResponseEntity<?> getMonitorPluginsSchema(ProxyExchange<?> proxy,
-                                                   @PathVariable String tenantId) {
+  @GetMapping("/schema/monitor/plugins")
+  public ResponseEntity<?> getMonitorPluginsSchema(ProxyExchange<?> proxy) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
-        .path("/api/tenant/{tenantId}/monitor-plugins-schema")
-        .build(tenantId)
-        .toString();
+        .path("/schema/monitor/plugins")
+        .toUriString();
 
     return proxy.uri(backendUri).get();
   }

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorsController.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorsController.java
@@ -160,11 +160,11 @@ public class MonitorsController {
     return proxy.uri(backendUri).get();
   }
 
-  @GetMapping("/schema/monitor/plugins")
+  @GetMapping("/tenant/{tenantId}/schema/monitor-plugins")
   public ResponseEntity<?> getMonitorPluginsSchema(ProxyExchange<?> proxy) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
-        .path("/schema/monitor/plugins")
+        .path("/schema/monitor-plugins")
         .toUriString();
 
     return proxy.uri(backendUri).get();

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorsController.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorsController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -154,6 +154,18 @@ public class MonitorsController {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
         .path("/api/tenant/{tenantId}/monitor-label-selectors")
+        .build(tenantId)
+        .toString();
+
+    return proxy.uri(backendUri).get();
+  }
+
+  @GetMapping("/tenant/{tenantId}/monitor-plugins-schema")
+  public ResponseEntity<?> getMonitorPluginsSchema(ProxyExchange<?> proxy,
+                                                   @PathVariable String tenantId) {
+    final String backendUri = UriComponentsBuilder
+        .fromUriString(servicesProperties.getMonitorManagementUrl())
+        .path("/api/tenant/{tenantId}/monitor-plugins-schema")
         .build(tenantId)
         .toString();
 


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-788

# What

Adds the public API endpoint corresponding to https://github.com/racker/salus-telemetry-monitor-management/pull/144