### PR TITLE
Use list for roles instead of array

### DIFF
--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/config/ApiAdminProperties.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/config/ApiAdminProperties.java
@@ -17,6 +17,7 @@
 package com.rackspace.salus.telemetry.api.config;
 
 import com.rackspace.salus.telemetry.model.LabelNamespaces;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import lombok.Data;
@@ -32,7 +33,7 @@ public class ApiAdminProperties {
    * The roles (without "ROLE_" prefix) that are required to allow the user to make use of tenant APIs.
    * Identity roles are translated to this format via {@link com.rackspace.salus.common.web.PreAuthenticatedFilter}.
    */
-  String[] roles = new String[]{};
+  List<String> roles = new ArrayList<>();
 
   /**
    * When registering an agent release, these are the labels that are required to be present

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/config/TenantWebSecurityConfig.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/config/TenantWebSecurityConfig.java
@@ -48,6 +48,6 @@ public class TenantWebSecurityConfig extends WebSecurityConfigurerAdapter {
         )
         .authorizeRequests()
         .antMatchers("/api/**")
-        .hasAnyRole(apiAdminProperties.getRoles());
+        .hasAnyRole(apiAdminProperties.getRoles().toArray(new String[0]));
   }
 }


### PR DESCRIPTION
Same as https://github.com/racker/salus-telemetry-api/pull/73 but for the admin api

The current data type does not allow for a list of roles to be specified via environment variables.  This fixes it.

---

With these environment variables
```
SALUS_API_ADMIN_ROLES_0_=OBSERVER
SALUS_API_ADMIN_ROLES_1_=TEST
```

and with this changes roles get read like so
```
Configuring tenant web security to authorize roles: [OBSERVER, TEST]
```

Without it the logs show
```
Configuring tenant web security to authorize roles: OBSERVER
```