### PR TITLE
Added support for secure RestTemplate

### DIFF
--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/config/WebConfig.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/config/WebConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.rackspace.salus.telemetry.api.config;
 
+import com.rackspace.salus.common.web.EnableSecureRestTemplate;
 import com.rackspace.salus.common.web.RequestLogging;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
@@ -24,6 +25,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @Slf4j
+@EnableSecureRestTemplate
 public class WebConfig implements WebMvcConfigurer {
 
   @Override

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/config/WebConfig.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/config/WebConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.rackspace.salus.telemetry.api.config;
 
+import com.rackspace.salus.common.web.EnableSecureRestTemplate;
 import com.rackspace.salus.common.web.RequestLogging;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
@@ -24,6 +25,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @Slf4j
+@EnableSecureRestTemplate
 public class WebConfig implements WebMvcConfigurer {
 
   @Override


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-716

# What

We need to enable secure communication between the admin/public API proxy and the backend microservices.

# How

Use the new `EnableSecureRestTemplate` annotation/configuration in https://github.com/racker/salus-common/pull/54 to conditionally activate secure `RestTemplate` instances.

## How to test

Tested as part of https://github.com/racker/salus-common/pull/54