### PR TITLE
Added httpclient dep to admin pom

### DIFF
--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2019 Rackspace US, Inc.
+  ~ Copyright 2020 Rackspace US, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -40,6 +40,10 @@
           <artifactId>spring-boot-starter-tomcat</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
# Resolves

Support https://jira.rax.io/browse/SALUS-716

# What

Missed adding the httpclient dependency as part of https://github.com/racker/salus-telemetry-api/pull/78 . The public-api pom already had it and unfortunately that was the one I was using for testing.

Without this change we were seeing this type of startup issue in dev cluster
```
Caused by: java.lang.ClassNotFoundException: org.apache.http.client.HttpClient
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
	... 19 common frames omitted
```

cc @shawnashlee 