### PR TITLE
Added monitors schema endpoint

### DIFF
--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorsController.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorsController.java
@@ -192,6 +192,19 @@ public class MonitorsController {
     return proxy.uri(backendUri).get();
   }
 
+  @GetMapping("/tenant/{tenantId}/schema/monitors")
+  public ResponseEntity<?> getMonitorsSchema(ProxyExchange<?> proxy,
+                                             @RequestHeader HttpHeaders headers) {
+    final String backendUri = UriComponentsBuilder
+        .fromUriString(servicesProperties.getMonitorManagementUrl())
+        .path("/schema/monitors")
+        .toUriString();
+
+    ApiUtils.applyRequiredHeaders(proxy, headers);
+
+    return proxy.uri(backendUri).get();
+  }
+
   @GetMapping("/tenant/{tenantId}/bound-monitors")
   public ResponseEntity<?> getAllBoundMonitors(ProxyExchange<?> proxy,
                                                @PathVariable String tenantId,


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-843

# What

The `/schema/monitor-plugins` is useful for informational purposes, but the UI's model validation really needed a JSON schema that was rooted at the `DetailedMonitorInput`.

# How

Added an API endpoint that uses the same strategy as `/monitor-plugins`.

# Depends on

https://github.com/racker/salus-telemetry-monitor-management/pull/159