### PR TITLE
Update tenant authentication

### DIFF
--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/config/TenantWebSecurityConfig.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/config/TenantWebSecurityConfig.java
@@ -43,7 +43,7 @@ public class TenantWebSecurityConfig extends WebSecurityConfigurerAdapter {
     http
         .csrf().disable()
         .addFilterBefore(
-            new ReposeHeaderFilter(),
+            new ReposeHeaderFilter(false),
             BasicAuthenticationFilter.class
         )
         .authorizeRequests()

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/config/TenantWebSecurityConfig.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/config/TenantWebSecurityConfig.java
@@ -43,7 +43,7 @@ public class TenantWebSecurityConfig extends WebSecurityConfigurerAdapter {
     http
         .csrf().disable()
         .addFilterBefore(
-            new ReposeHeaderFilter(),
+            new ReposeHeaderFilter(true),
             BasicAuthenticationFilter.class
         )
         .authorizeRequests()


### PR DESCRIPTION
Follows on from https://github.com/racker/salus-common/pull/63/files

Requires a tenantId to be provided via `Requested-Tenant-Id` header for public api but not for admin api.