### PR TITLE
Admin API Policy Opt-Out Endpoint

### DIFF
--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorPolicyController.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorPolicyController.java
@@ -194,4 +194,19 @@ public class MonitorPolicyController {
 
     return proxy.uri(backendUri).delete();
   }
+
+  @PostMapping("/policies/monitors/opt-out")
+  public ResponseEntity<?> optOutPolicy(ProxyExchange<?> proxy,
+      @RequestHeader HttpHeaders headers) {
+    final String backendUri = UriComponentsBuilder
+        .fromUriString(servicesProperties.getPolicyManagementUrl())
+        .path("/api/admin/policy/monitors/opt-out")
+        .build()
+        .toString();
+
+    ApiUtils.applyRequiredHeaders(proxy, headers);
+
+    return proxy.uri(backendUri)
+        .post();
+  }
 }


### PR DESCRIPTION
# What

Adds the admin api proxy for policy management's opt-out endpoint

## How to test

<img width="1025" alt="image" src="https://user-images.githubusercontent.com/4358210/82490469-8da3f980-9aa0-11ea-82b9-31e47da163c9.png">


# Why

So internal support people can help customer's opt-out out of their default policies, such as ping monitoring on every device.