### PR TITLE
Remove dependency on umb-protocol

### DIFF
--- a/public/pom.xml
+++ b/public/pom.xml
@@ -137,11 +137,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.rackspace.monplat</groupId>
-            <artifactId>umb-protocol</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
-        </dependency>
-        <dependency>
             <groupId>com.rackspace.salus</groupId>
             <artifactId>salus-event-engine-common</artifactId>
             <version>0.1.0-SNAPSHOT</version>


### PR DESCRIPTION
# What

By removing the use of UniversalMetricFrame.MonitoringSystem in the event objects (https://github.com/racker/salus-event-engine-management) it removes the need for us to pull in the protocol dependency here.

Previously it was needed to allow the event-engine client dependency to work.
