### PR TITLE
Added logical operator AND in url endpoint for resource-management

### DIFF
--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/ResourcesController.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/ResourcesController.java
@@ -91,7 +91,7 @@ public class ResourcesController {
                                                   @RequestParam Map<String, String> labels) {
     final UriComponentsBuilder builder = UriComponentsBuilder
         .fromUriString(servicesProperties.getResourceManagementUrl())
-        .path("/api/tenant/{tenantId}/resources-by-label");
+        .path("/api/tenant/{tenantId}/resources-by-label/AND");
 
     labels.forEach(builder::queryParam);
 

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/ResourcesController.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/ResourcesController.java
@@ -84,19 +84,20 @@ public class ResourcesController {
     return proxy.uri(backendUri).get();
   }
 
-  @GetMapping("/tenant/{tenantId}/resources-by-label")
+  @GetMapping("/tenant/{tenantId}/resources-by-label/{logicalOperator}")
   public ResponseEntity<?> getResourcesWithLabels(ProxyExchange<?> proxy,
                                                   @PathVariable String tenantId,
+                                                  @PathVariable String logicalOperator,
                                                   @RequestHeader HttpHeaders headers,
                                                   @RequestParam Map<String, String> labels) {
     final UriComponentsBuilder builder = UriComponentsBuilder
         .fromUriString(servicesProperties.getResourceManagementUrl())
-        .path("/api/tenant/{tenantId}/resources-by-label/AND");
+        .path("/api/tenant/{tenantId}/resources-by-label/{logicalOperator}");
 
     labels.forEach(builder::queryParam);
 
     final String backendUri = builder
-        .buildAndExpand(tenantId)
+        .buildAndExpand(tenantId, logicalOperator)
         .toUriString();
 
     ApiUtils.applyRequiredHeaders(proxy, headers);


### PR DESCRIPTION
# Resolves

[SALUS-1076](https://jira.rax.io/browse/SALUS-1076)

# What

Getting "404 Not Found" in Get call for getting resources by label using the Public API

# Depends on

https://github.com/racker/salus-telemetry-resource-management/pull/96
https://github.com/racker/salus-telemetry-bundle/pull/150