### PR TITLE
fixed - Search by resource ID with space fails with 500

### DIFF
--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/ResourcesController.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/ResourcesController.java
@@ -20,8 +20,9 @@ package com.rackspace.salus.telemetry.api.web;
 import com.rackspace.salus.common.util.ApiUtils;
 import com.rackspace.salus.telemetry.api.config.ServicesProperties;
 import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
+import java.net.URI;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.mvc.ProxyExchange;
 import org.springframework.http.HttpHeaders;
@@ -42,6 +43,7 @@ import org.springframework.web.util.UriComponentsBuilder;
  * to proxy calls to the resource-management service.
  */
 @RestController
+@Slf4j
 @SuppressWarnings("Duplicates") // due to repetitive proxy setup/calls
 public class ResourcesController {
 
@@ -74,11 +76,12 @@ public class ResourcesController {
       @PathVariable String tenantId,
       @RequestHeader HttpHeaders headers,
       @PathVariable String resourceId) throws UnsupportedEncodingException {
-    String backendUri = UriComponentsBuilder
+
+    URI backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getResourceManagementUrl())
         .path("/api/tenant/{tenantId}/resources/{resourceId}")
-        .buildAndExpand(tenantId, URLEncoder.encode(resourceId,"UTF-8"))
-        .toUriString();
+        .buildAndExpand(tenantId, resourceId)
+        .toUri();
 
     ApiUtils.applyRequiredHeaders(proxy, headers);
 
@@ -171,11 +174,12 @@ public class ResourcesController {
                                   @PathVariable String tenantId,
                                   @PathVariable String resourceId,
                                   @RequestHeader HttpHeaders headers) {
-    final String backendUri = UriComponentsBuilder
+
+    final URI backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getResourceManagementUrl())
         .path("/api/tenant/{tenantId}/resources/{resourceId}")
         .buildAndExpand(tenantId, resourceId)
-        .toUriString();
+        .toUri();
 
     ApiUtils.applyRequiredHeaders(proxy, headers);
 
@@ -188,11 +192,11 @@ public class ResourcesController {
                                   @PathVariable String resourceId,
                                   @RequestHeader HttpHeaders headers) {
 
-    final String backendUri = UriComponentsBuilder
+    final URI backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getResourceManagementUrl())
         .path("/api/tenant/{tenantId}/resources/{resourceId}")
         .buildAndExpand(tenantId, resourceId)
-        .toUriString();
+        .toUri();
 
     ApiUtils.applyRequiredHeaders(proxy, headers);
 

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/ResourcesController.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/ResourcesController.java
@@ -19,6 +19,8 @@ package com.rackspace.salus.telemetry.api.web;
 
 import com.rackspace.salus.common.util.ApiUtils;
 import com.rackspace.salus.telemetry.api.config.ServicesProperties;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.mvc.ProxyExchange;
@@ -71,12 +73,11 @@ public class ResourcesController {
   public ResponseEntity<?> getOne(ProxyExchange<?> proxy,
       @PathVariable String tenantId,
       @RequestHeader HttpHeaders headers,
-      @PathVariable String resourceId) {
-
-    final String backendUri = UriComponentsBuilder
+      @PathVariable String resourceId) throws UnsupportedEncodingException {
+    String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getResourceManagementUrl())
         .path("/api/tenant/{tenantId}/resources/{resourceId}")
-        .buildAndExpand(tenantId, resourceId)
+        .buildAndExpand(tenantId, URLEncoder.encode(resourceId,"UTF-8"))
         .toUriString();
 
     ApiUtils.applyRequiredHeaders(proxy, headers);

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/ResourcesController.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/ResourcesController.java
@@ -22,7 +22,6 @@ import com.rackspace.salus.telemetry.api.config.ServicesProperties;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.util.Map;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.mvc.ProxyExchange;
 import org.springframework.http.HttpHeaders;
@@ -43,7 +42,6 @@ import org.springframework.web.util.UriComponentsBuilder;
  * to proxy calls to the resource-management service.
  */
 @RestController
-@Slf4j
 @SuppressWarnings("Duplicates") // due to repetitive proxy setup/calls
 public class ResourcesController {
 

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/ResourcesController.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/ResourcesController.java
@@ -19,7 +19,6 @@ package com.rackspace.salus.telemetry.api.web;
 
 import com.rackspace.salus.common.util.ApiUtils;
 import com.rackspace.salus.telemetry.api.config.ServicesProperties;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -73,9 +72,9 @@ public class ResourcesController {
   public ResponseEntity<?> getOne(ProxyExchange<?> proxy,
       @PathVariable String tenantId,
       @RequestHeader HttpHeaders headers,
-      @PathVariable String resourceId) throws UnsupportedEncodingException {
+      @PathVariable String resourceId) {
 
-    URI backendUri = UriComponentsBuilder
+    final URI backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getResourceManagementUrl())
         .path("/api/tenant/{tenantId}/resources/{resourceId}")
         .buildAndExpand(tenantId, resourceId)


### PR DESCRIPTION
# Resolves

[SALUS-1073](https://jira.rax.io/browse/SALUS-1073)

# What

Search by resource ID with space fails with 500