### PR TITLE
used UriComponentsBuilder uri method instead of uriString to handle white spaces in url path for all methods uses queryParams in MonitorsController

### DIFF
--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorsController.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorsController.java
@@ -19,6 +19,7 @@ package com.rackspace.salus.telemetry.api.web;
 
 import com.rackspace.salus.common.util.ApiUtils;
 import com.rackspace.salus.telemetry.api.config.ServicesProperties;
+import java.net.URI;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.mvc.ProxyExchange;
@@ -59,12 +60,12 @@ public class MonitorsController {
                                   @PathVariable String tenantId,
                                   @RequestHeader HttpHeaders headers,
                                   @RequestParam MultiValueMap<String,String> queryParams) {
-    final String backendUri = UriComponentsBuilder
+    final URI backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
         .path("/api/tenant/{tenantId}/monitors")
         .queryParams(queryParams)
         .buildAndExpand(tenantId)
-        .toUriString();
+        .toUri();
 
     ApiUtils.applyRequiredHeaders(proxy, headers);
 
@@ -211,12 +212,12 @@ public class MonitorsController {
                                                @PathVariable String tenantId,
                                                @RequestHeader HttpHeaders headers,
                                                @RequestParam MultiValueMap<String,String> queryParams) {
-    final String backendUri = UriComponentsBuilder
+    final URI backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
         .path("/api/tenant/{tenantId}/bound-monitors")
         .queryParams(queryParams)
         .buildAndExpand(tenantId)
-        .toUriString();
+        .toUri();
 
     ApiUtils.applyRequiredHeaders(proxy, headers);
 
@@ -228,12 +229,12 @@ public class MonitorsController {
       @PathVariable String tenantId,
       @RequestHeader HttpHeaders headers,
       @RequestParam MultiValueMap<String,String> queryParams) {
-    final String backendUri = UriComponentsBuilder
+    final URI backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
         .path("/api/tenant/{tenantId}/search")
         .queryParams(queryParams)
         .buildAndExpand(tenantId)
-        .toUriString();
+        .toUri();
 
     ApiUtils.applyRequiredHeaders(proxy, headers);
 


### PR DESCRIPTION
# Resolves

[SALUS-1090](https://jira.rax.io/browse/SALUS-1090)

# What

monitors-search with space fails with 500 as UriComponentsBuilder.toUriString() was unable to form a URL string with white spaces

# How

Used UriComponentsBuilder.toUri() instead of toUriString() to handle white spaces in request URL
