### PR TITLE
Changes corresponding to replacing Repose with IdentityAuthFilter

### DIFF
--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/TelemetryAdminApiApplication.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/TelemetryAdminApiApplication.java
@@ -16,10 +16,13 @@
 
 package com.rackspace.salus.telemetry.api;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.common.util.DumpConfigProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import com.rackspace.salus.common.config.AutoConfigureSalusAppMetrics;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
 @AutoConfigureSalusAppMetrics
@@ -29,5 +32,15 @@ public class TelemetryAdminApiApplication {
     DumpConfigProperties.process(args);
 
     SpringApplication.run(TelemetryAdminApiApplication.class, args);
+  }
+
+  @Bean
+  public RestTemplate getRestTemplate() {
+    return new RestTemplate();
+  }
+
+  @Bean
+  public ObjectMapper getObjectMapper() {
+    return new ObjectMapper();
   }
 }

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/web/AgentReleasesController.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/web/AgentReleasesController.java
@@ -18,6 +18,7 @@ package com.rackspace.salus.telemetry.api.web;
 
 import com.rackspace.salus.common.util.ApiUtils;
 import com.rackspace.salus.telemetry.api.config.ServicesProperties;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.mvc.ProxyExchange;
 import org.springframework.http.HttpHeaders;
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -47,8 +49,9 @@ public class AgentReleasesController {
 
   @GetMapping("/agent-releases")
   public ResponseEntity<?> getAll(ProxyExchange<?> proxy,
-                                  @RequestHeader HttpHeaders headers,
-                                  @RequestParam MultiValueMap<String,String> queryParams) {
+      @RequestHeader HttpHeaders headers,
+      @RequestParam MultiValueMap<String, String> queryParams,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getAgentCatalogManagementUrl())
         .path("/api/admin/agent-releases")
@@ -56,29 +59,31 @@ public class AgentReleasesController {
         .buildAndExpand()
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
 
   @GetMapping("/agent-releases/{agentReleaseId}")
   public ResponseEntity<?> getOne(ProxyExchange<?> proxy,
-                                  @PathVariable String agentReleaseId,
-                                  @RequestHeader HttpHeaders headers) {
+      @PathVariable String agentReleaseId,
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getAgentCatalogManagementUrl())
         .path("/api/admin/agent-releases/{agentReleaseId}")
         .buildAndExpand(agentReleaseId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
 
   @PostMapping("/agent-releases")
   public ResponseEntity<?> declareAgentRelease(ProxyExchange<?> proxy,
-                                               @RequestHeader HttpHeaders headers) {
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getAgentCatalogManagementUrl())
@@ -86,22 +91,23 @@ public class AgentReleasesController {
         .buildAndExpand()
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).post();
   }
 
   @DeleteMapping("/agent-releases/{agentReleaseId}")
   public ResponseEntity<?> deleteOne(ProxyExchange<?> proxy,
-                                     @PathVariable String agentReleaseId,
-                                     @RequestHeader HttpHeaders headers) {
+      @PathVariable String agentReleaseId,
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getAgentCatalogManagementUrl())
         .path("/api/admin/agent-releases/{agentReleaseId}")
         .buildAndExpand(agentReleaseId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).delete();
   }

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/web/CrossServiceController.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/web/CrossServiceController.java
@@ -22,6 +22,7 @@ import com.rackspace.salus.telemetry.api.config.ServicesProperties;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import org.eclipse.jetty.http.HttpStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.mvc.ProxyExchange;
@@ -30,6 +31,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -51,9 +53,10 @@ public class CrossServiceController {
   @DeleteMapping("/tenant/{tenantId}")
   public ResponseEntity<?> deleteAll(ProxyExchange<?> proxy,
       @RequestHeader HttpHeaders headers,
-      @RequestParam MultiValueMap<String,String> queryParams,
+      @RequestParam MultiValueMap<String, String> queryParams,
       @PathVariable String tenantId,
-      @RequestParam(defaultValue = "true") boolean removeTenantMetadata) {
+      @RequestParam(defaultValue = "true") boolean removeTenantMetadata,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     queryParams.add("sendEvents", "false");
     List bodies = new LinkedList();
 
@@ -65,10 +68,10 @@ public class CrossServiceController {
         .buildAndExpand(tenantId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     ResponseEntity<?> agentInstalls = proxy.uri(agentCatalogManagementURI).delete();
-    if(agentInstalls.getStatusCode().isError()) {
+    if (agentInstalls.getStatusCode().isError()) {
       bodies.add(agentInstalls.getBody());
     }
 
@@ -80,11 +83,11 @@ public class CrossServiceController {
         .buildAndExpand(tenantId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     ResponseEntity<?> envoyTokens = proxy.uri(authURI).delete();
 
-    if(envoyTokens.getStatusCode().isError()) {
+    if (envoyTokens.getStatusCode().isError()) {
       bodies.add(envoyTokens.getBody());
     }
 
@@ -98,7 +101,7 @@ public class CrossServiceController {
 
     ResponseEntity<?> eventResponse = proxy.uri(eventEngineURI).delete();
 
-    if(eventResponse.getStatusCode().isError()) {
+    if (eventResponse.getStatusCode().isError()) {
       bodies.add(eventResponse.getBody());
     }
 
@@ -112,7 +115,7 @@ public class CrossServiceController {
 
     ResponseEntity<?> resource = proxy.uri(resourcesURI).delete();
 
-    if(resource.getStatusCode().isError()) {
+    if (resource.getStatusCode().isError()) {
       bodies.add(resource.getBody());
     }
 
@@ -126,12 +129,12 @@ public class CrossServiceController {
 
     ResponseEntity<?> monitor = proxy.uri(monitorsURI).delete();
 
-    if(monitor.getStatusCode().isError()) {
+    if (monitor.getStatusCode().isError()) {
       bodies.add(monitor.getBody());
     }
 
     // delete tenant metadata
-    if(removeTenantMetadata) {
+    if (removeTenantMetadata) {
       final String tenantMetadataURI = UriComponentsBuilder
           .fromUriString(servicesProperties.getPolicyManagementUrl())
           .path("/api/admin/tenant-metadata/{tenantId}")
@@ -156,11 +159,11 @@ public class CrossServiceController {
 
     ResponseEntity<?> zone = proxy.uri(zonesURI).delete();
 
-    if(zone.getStatusCode().isError()) {
+    if (zone.getStatusCode().isError()) {
       bodies.add(zone.getBody());
     }
 
-    if(!bodies.isEmpty()) {
+    if (!bodies.isEmpty()) {
       LinkedHashMap responseBody = new LinkedHashMap();
 
       responseBody.put("messages", bodies);
@@ -170,8 +173,6 @@ public class CrossServiceController {
 
     return ResponseEntity.status(HttpStatus.ACCEPTED_202).headers(headers).build();
   }
-
-
 
 
 }

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorMetadataPolicyController.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorMetadataPolicyController.java
@@ -20,6 +20,7 @@ import com.rackspace.salus.common.util.ApiUtils;
 import com.rackspace.salus.telemetry.api.config.ServicesProperties;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import com.rackspace.salus.telemetry.model.TargetClassName;
+import java.util.Map;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +33,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -53,7 +55,8 @@ public class MonitorMetadataPolicyController {
   @GetMapping("/policy/metadata/monitor")
   public ResponseEntity<?> getAllMetadataPoliciesForMonitors(ProxyExchange<?> proxy,
       @RequestHeader HttpHeaders headers,
-      @RequestParam MultiValueMap<String,String> queryParams) {
+      @RequestParam MultiValueMap<String,String> queryParams,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getPolicyManagementUrl())
@@ -62,7 +65,7 @@ public class MonitorMetadataPolicyController {
         .buildAndExpand()
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
@@ -71,7 +74,8 @@ public class MonitorMetadataPolicyController {
   public ResponseEntity<?> getMetadataPolicyForMonitors(ProxyExchange<?> proxy,
       @PathVariable UUID uuid,
       @RequestHeader HttpHeaders headers,
-      @RequestParam MultiValueMap<String,String> queryParams) {
+      @RequestParam MultiValueMap<String,String> queryParams,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getPolicyManagementUrl())
@@ -80,14 +84,15 @@ public class MonitorMetadataPolicyController {
         .buildAndExpand(uuid)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
 
   @PostMapping("/policy/metadata/monitor")
   public ResponseEntity<?> createMetadataPolicyForMonitors(ProxyExchange<?> proxy,
-      @RequestHeader HttpHeaders headers) {
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getPolicyManagementUrl())
@@ -95,7 +100,7 @@ public class MonitorMetadataPolicyController {
         .buildAndExpand()
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri)
         .post();
@@ -104,7 +109,8 @@ public class MonitorMetadataPolicyController {
   @PutMapping("/policy/metadata/monitor/{uuid}")
   public ResponseEntity<?> updateMetadataPolicyForMonitors(ProxyExchange<?> proxy,
       @PathVariable UUID uuid,
-      @RequestHeader HttpHeaders headers) {
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getPolicyManagementUrl())
@@ -112,7 +118,7 @@ public class MonitorMetadataPolicyController {
         .buildAndExpand(uuid)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).put();
   }
@@ -120,7 +126,8 @@ public class MonitorMetadataPolicyController {
   @DeleteMapping("/policy/metadata/monitor/{uuid}")
   public ResponseEntity<?> deleteMetadataPolicyForMonitors(ProxyExchange<?> proxy,
       @PathVariable UUID uuid,
-      @RequestHeader HttpHeaders headers) {
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getPolicyManagementUrl())
@@ -128,7 +135,7 @@ public class MonitorMetadataPolicyController {
         .buildAndExpand(uuid)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).delete();
   }
@@ -137,7 +144,8 @@ public class MonitorMetadataPolicyController {
   public ResponseEntity<?> getEffectiveMetadataPolicyForMonitorsByTenant(ProxyExchange<?> proxy,
       @PathVariable String tenantId,
       @RequestHeader HttpHeaders headers,
-      @RequestParam MultiValueMap<String,String> queryParams) {
+      @RequestParam MultiValueMap<String,String> queryParams,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getPolicyManagementUrl())
@@ -146,7 +154,7 @@ public class MonitorMetadataPolicyController {
         .buildAndExpand(tenantId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
@@ -157,7 +165,8 @@ public class MonitorMetadataPolicyController {
       @PathVariable TargetClassName className,
       @PathVariable MonitorType monitorType,
       @RequestHeader HttpHeaders headers,
-      @RequestParam MultiValueMap<String,String> queryParams) {
+      @RequestParam MultiValueMap<String,String> queryParams,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getPolicyManagementUrl())
@@ -166,14 +175,15 @@ public class MonitorMetadataPolicyController {
         .buildAndExpand(tenantId, className, monitorType)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
 
   @PostMapping("/policy/metadata/zones")
   public ResponseEntity<?> createMetadataPolicyForZones(ProxyExchange<?> proxy,
-      @RequestHeader HttpHeaders headers) {
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getPolicyManagementUrl())
@@ -181,7 +191,7 @@ public class MonitorMetadataPolicyController {
         .buildAndExpand()
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri)
         .post();
@@ -190,7 +200,8 @@ public class MonitorMetadataPolicyController {
   @PutMapping("/policy/metadata/zones/{region}")
   public ResponseEntity<?> updateMetadataPolicyForZones(ProxyExchange<?> proxy,
       @PathVariable String region,
-      @RequestHeader HttpHeaders headers) {
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getPolicyManagementUrl())
@@ -198,7 +209,7 @@ public class MonitorMetadataPolicyController {
         .buildAndExpand(region)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).put();
   }
@@ -206,7 +217,8 @@ public class MonitorMetadataPolicyController {
   @DeleteMapping("/policy/metadata/zones/{region}")
   public ResponseEntity<?> deleteMetadataPolicyForZones(ProxyExchange<?> proxy,
       @PathVariable String region,
-      @RequestHeader HttpHeaders headers) {
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getPolicyManagementUrl())
@@ -214,7 +226,7 @@ public class MonitorMetadataPolicyController {
         .buildAndExpand(region)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).delete();
   }

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorPolicyController.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorPolicyController.java
@@ -18,6 +18,7 @@ package com.rackspace.salus.telemetry.api.web;
 
 import com.rackspace.salus.common.util.ApiUtils;
 import com.rackspace.salus.telemetry.api.config.ServicesProperties;
+import java.util.Map;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,6 +31,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -51,7 +53,8 @@ public class MonitorPolicyController {
   @GetMapping("/monitor-templates")
   public ResponseEntity<?> getAllMonitorTemplates(ProxyExchange<?> proxy,
       @RequestHeader HttpHeaders headers,
-      @RequestParam MultiValueMap<String,String> queryParams) {
+      @RequestParam MultiValueMap<String,String> queryParams,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
@@ -60,7 +63,7 @@ public class MonitorPolicyController {
         .buildAndExpand()
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
@@ -69,7 +72,8 @@ public class MonitorPolicyController {
   public ResponseEntity<?> getMonitorTemplate(ProxyExchange<?> proxy,
       @PathVariable UUID uuid,
       @RequestHeader HttpHeaders headers,
-      @RequestParam MultiValueMap<String,String> queryParams) {
+      @RequestParam MultiValueMap<String,String> queryParams,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
@@ -78,14 +82,15 @@ public class MonitorPolicyController {
         .buildAndExpand(uuid)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
 
   @PostMapping("/monitor-templates")
   public ResponseEntity<?> createMonitorTemplates(ProxyExchange<?> proxy,
-      @RequestHeader HttpHeaders headers) {
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
@@ -93,7 +98,7 @@ public class MonitorPolicyController {
         .buildAndExpand()
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).post();
   }
@@ -101,7 +106,8 @@ public class MonitorPolicyController {
   @PutMapping("/monitor-templates/{uuid}")
   public ResponseEntity<?> updateMonitorTemplates(ProxyExchange<?> proxy,
       @PathVariable UUID uuid,
-      @RequestHeader HttpHeaders headers) {
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
@@ -109,7 +115,7 @@ public class MonitorPolicyController {
         .buildAndExpand(uuid)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).put();
   }
@@ -117,7 +123,8 @@ public class MonitorPolicyController {
   @DeleteMapping("/monitor-templates/{uuid}")
   public ResponseEntity<?> deleteMonitorTemplates(ProxyExchange<?> proxy,
       @PathVariable UUID uuid,
-      @RequestHeader HttpHeaders headers) {
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
@@ -125,7 +132,7 @@ public class MonitorPolicyController {
         .buildAndExpand(uuid)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).delete();
   }
@@ -133,7 +140,8 @@ public class MonitorPolicyController {
   @GetMapping("/policies/monitors")
   public ResponseEntity<?> getAllMonitorPolicies(ProxyExchange<?> proxy,
       @RequestHeader HttpHeaders headers,
-      @RequestParam MultiValueMap<String,String> queryParams) {
+      @RequestParam MultiValueMap<String,String> queryParams,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getPolicyManagementUrl())
@@ -142,7 +150,7 @@ public class MonitorPolicyController {
         .buildAndExpand()
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
@@ -151,7 +159,8 @@ public class MonitorPolicyController {
   public ResponseEntity<?> getAllMonitorPolicies(ProxyExchange<?> proxy,
       @PathVariable UUID uuid,
       @RequestHeader HttpHeaders headers,
-      @RequestParam MultiValueMap<String,String> queryParams) {
+      @RequestParam MultiValueMap<String,String> queryParams,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getPolicyManagementUrl())
@@ -160,21 +169,22 @@ public class MonitorPolicyController {
         .buildAndExpand(uuid)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
 
   @PostMapping("/policies/monitors")
   public ResponseEntity<?> createPolicy(ProxyExchange<?> proxy,
-      @RequestHeader HttpHeaders headers) {
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getPolicyManagementUrl())
         .path("/api/admin/policy/monitors")
         .buildAndExpand()
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri)
         .post();
@@ -183,28 +193,30 @@ public class MonitorPolicyController {
   @DeleteMapping("/policies/monitors/{uuid}")
   public ResponseEntity<?> deletePolicy(ProxyExchange<?> proxy,
       @PathVariable UUID uuid,
-      @RequestHeader HttpHeaders headers) {
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getPolicyManagementUrl())
         .path("/api/admin/policy/monitors/{uuid}")
         .buildAndExpand(uuid)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).delete();
   }
 
   @PostMapping("/policies/monitors/opt-out")
   public ResponseEntity<?> optOutPolicy(ProxyExchange<?> proxy,
-      @RequestHeader HttpHeaders headers) {
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getPolicyManagementUrl())
         .path("/api/admin/policy/monitors/opt-out")
         .buildAndExpand()
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri)
         .post();
@@ -214,7 +226,8 @@ public class MonitorPolicyController {
   public ResponseEntity<?> getEffectivePoliciesByTenantId(ProxyExchange<?> proxy,
       @PathVariable String tenantId,
       @RequestHeader HttpHeaders headers,
-      @RequestParam MultiValueMap<String,String> queryParams) {
+      @RequestParam MultiValueMap<String,String> queryParams,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getPolicyManagementUrl())
@@ -223,7 +236,7 @@ public class MonitorPolicyController {
         .buildAndExpand(tenantId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
@@ -232,7 +245,8 @@ public class MonitorPolicyController {
   public ResponseEntity<?> getEffectiveMonitorIdsUsingMonitorPoliciesForTenant(ProxyExchange<?> proxy,
       @PathVariable String tenantId,
       @RequestHeader HttpHeaders headers,
-      @RequestParam MultiValueMap<String,String> queryParams) {
+      @RequestParam MultiValueMap<String,String> queryParams,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getPolicyManagementUrl())
@@ -241,7 +255,7 @@ public class MonitorPolicyController {
         .buildAndExpand(tenantId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
@@ -251,7 +265,8 @@ public class MonitorPolicyController {
       @PathVariable String tenantId,
       @RequestParam(required = false, defaultValue = "true") boolean includeNullMonitors,
       @RequestHeader HttpHeaders headers,
-      @RequestParam MultiValueMap<String,String> queryParams) {
+      @RequestParam MultiValueMap<String,String> queryParams,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getPolicyManagementUrl())
@@ -260,7 +275,7 @@ public class MonitorPolicyController {
         .buildAndExpand(tenantId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorTranslationController.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorTranslationController.java
@@ -18,6 +18,7 @@ package com.rackspace.salus.telemetry.api.web;
 
 import com.rackspace.salus.common.util.ApiUtils;
 import com.rackspace.salus.telemetry.api.config.ServicesProperties;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.mvc.ProxyExchange;
@@ -28,6 +29,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -50,7 +52,8 @@ public class MonitorTranslationController {
   @GetMapping("/monitor-translations")
   public ResponseEntity<?> getAll(ProxyExchange<?> proxy,
                                   @RequestHeader HttpHeaders headers,
-                                  @RequestParam MultiValueMap<String, String> queryParams) {
+                                  @RequestParam MultiValueMap<String, String> queryParams,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
@@ -59,7 +62,7 @@ public class MonitorTranslationController {
         .build()
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
@@ -67,28 +70,30 @@ public class MonitorTranslationController {
   @GetMapping("/monitor-translations/{id}")
   public ResponseEntity<?> getById(ProxyExchange<?> proxy,
                                    @PathVariable String id,
-                                   @RequestHeader HttpHeaders headers) {
+                                   @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
         .path("/api/admin/monitor-translations/{id}")
         .buildAndExpand(id)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
 
   @PostMapping("/monitor-translations")
   public ResponseEntity<?> create(ProxyExchange<?> proxy,
-                                  @RequestHeader HttpHeaders headers) {
+                                  @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
         .path("/api/admin/monitor-translations")
         .build()
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).post();
   }
@@ -96,14 +101,15 @@ public class MonitorTranslationController {
   @DeleteMapping("/monitor-translations/{id}")
   public ResponseEntity<?> delete(ProxyExchange<?> proxy,
                                   @PathVariable String id,
-                                  @RequestHeader HttpHeaders headers) {
+                                  @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
         .path("/api/admin/monitor-translations/{id}")
         .buildAndExpand(id)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).delete();
   }

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorsController.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorsController.java
@@ -18,6 +18,7 @@ package com.rackspace.salus.telemetry.api.web;
 
 import com.rackspace.salus.common.util.ApiUtils;
 import com.rackspace.salus.telemetry.api.config.ServicesProperties;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.mvc.ProxyExchange;
@@ -25,6 +26,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -47,7 +49,8 @@ public class MonitorsController {
   @GetMapping("/monitors")
   public ResponseEntity<?> getAllMonitors(ProxyExchange<?> proxy,
                                   @RequestHeader HttpHeaders headers,
-                                  @RequestParam MultiValueMap<String,String> queryParams) {
+                                  @RequestParam MultiValueMap<String,String> queryParams,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
@@ -56,7 +59,7 @@ public class MonitorsController {
         .buildAndExpand()
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/web/PresenceMonitorController.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/web/PresenceMonitorController.java
@@ -18,12 +18,14 @@ package com.rackspace.salus.telemetry.api.web;
 
 import com.rackspace.salus.common.util.ApiUtils;
 import com.rackspace.salus.telemetry.api.config.ServicesProperties;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.mvc.ProxyExchange;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -44,7 +46,8 @@ public class PresenceMonitorController {
 
   @GetMapping("/presence-monitor/partitions")
   public ResponseEntity<?> getPresenceMonitorPartitions(ProxyExchange<?> proxy,
-      @RequestHeader HttpHeaders headers) {
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getPresenceMonitorUrl())
@@ -52,21 +55,22 @@ public class PresenceMonitorController {
         .buildAndExpand()
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
 
   @PutMapping("/presence-monitor/partitions")
   public ResponseEntity<?> changePresenceMonitorPartitions(ProxyExchange<?> proxy,
-      @RequestHeader HttpHeaders headers) {
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getPresenceMonitorUrl())
         .path("/api/admin/presence-monitor/partitions")
         .buildAndExpand()
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).put();
   }

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/web/ResourcesController.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/web/ResourcesController.java
@@ -18,12 +18,14 @@ package com.rackspace.salus.telemetry.api.web;
 
 import com.rackspace.salus.common.util.ApiUtils;
 import com.rackspace.salus.telemetry.api.config.ServicesProperties;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.mvc.ProxyExchange;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -44,7 +46,8 @@ public class ResourcesController {
   @GetMapping("/resources")
   public ResponseEntity<?> getAll(ProxyExchange<?> proxy,
                            @RequestHeader HttpHeaders headers,
-                           @RequestParam MultiValueMap<String,String> queryParams) {
+                           @RequestParam MultiValueMap<String,String> queryParams,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getResourceManagementUrl())
@@ -53,7 +56,7 @@ public class ResourcesController {
         .buildAndExpand()
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/web/TenantMetadataController.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/web/TenantMetadataController.java
@@ -18,6 +18,7 @@ package com.rackspace.salus.telemetry.api.web;
 
 import com.rackspace.salus.common.util.ApiUtils;
 import com.rackspace.salus.telemetry.api.config.ServicesProperties;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.mvc.ProxyExchange;
@@ -29,6 +30,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -50,7 +52,8 @@ public class TenantMetadataController {
   @GetMapping("/tenant-metadata")
   public ResponseEntity<?> getAllTenantMetadata(ProxyExchange<?> proxy,
       @RequestHeader HttpHeaders headers,
-      @RequestParam MultiValueMap<String,String> queryParams) {
+      @RequestParam MultiValueMap<String,String> queryParams,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getPolicyManagementUrl())
@@ -59,7 +62,7 @@ public class TenantMetadataController {
         .buildAndExpand()
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
@@ -68,7 +71,8 @@ public class TenantMetadataController {
   public ResponseEntity<?> getTenantMetadata(ProxyExchange<?> proxy,
       @PathVariable String tenantId,
       @RequestHeader HttpHeaders headers,
-      @RequestParam MultiValueMap<String,String> queryParams) {
+      @RequestParam MultiValueMap<String,String> queryParams,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getPolicyManagementUrl())
@@ -77,14 +81,15 @@ public class TenantMetadataController {
         .buildAndExpand(tenantId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
 
   @PostMapping("/tenant-metadata")
   public ResponseEntity<?> createTenantMetadata(ProxyExchange<?> proxy,
-      @RequestHeader HttpHeaders headers) {
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getPolicyManagementUrl())
@@ -92,7 +97,7 @@ public class TenantMetadataController {
         .buildAndExpand()
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).post();
   }
@@ -100,7 +105,8 @@ public class TenantMetadataController {
   @PutMapping("/tenant-metadata/{tenantId}")
   public ResponseEntity<?> upsertTenantMetadata(ProxyExchange<?> proxy,
       @PathVariable String tenantId,
-      @RequestHeader HttpHeaders headers) {
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getPolicyManagementUrl())
@@ -108,7 +114,7 @@ public class TenantMetadataController {
         .buildAndExpand(tenantId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).put();
   }
@@ -116,7 +122,8 @@ public class TenantMetadataController {
   @DeleteMapping("/tenant-metadata/{tenantId}")
   public ResponseEntity<?> deleteTenantMetadata(ProxyExchange<?> proxy,
       @PathVariable String tenantId,
-      @RequestHeader HttpHeaders headers) {
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getPolicyManagementUrl())
@@ -124,7 +131,7 @@ public class TenantMetadataController {
         .buildAndExpand(tenantId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).delete();
   }

--- a/admin/src/main/java/com/rackspace/salus/telemetry/api/web/ZonesController.java
+++ b/admin/src/main/java/com/rackspace/salus/telemetry/api/web/ZonesController.java
@@ -18,6 +18,7 @@ package com.rackspace.salus.telemetry.api.web;
 
 import com.rackspace.salus.common.util.ApiUtils;
 import com.rackspace.salus.telemetry.api.config.ServicesProperties;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.mvc.ProxyExchange;
 import org.springframework.http.HttpHeaders;
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -48,7 +50,8 @@ public class ZonesController {
   @GetMapping("/zones/**")
   public ResponseEntity<?> get(ProxyExchange<?> proxy,
       @RequestHeader HttpHeaders headers,
-      @RequestParam MultiValueMap<String,String> queryParams) {
+      @RequestParam MultiValueMap<String,String> queryParams,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String zone = proxy.path("/api/zones/");
 
     final String backendUri = UriComponentsBuilder
@@ -58,7 +61,7 @@ public class ZonesController {
         .buildAndExpand(zone)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
@@ -66,7 +69,8 @@ public class ZonesController {
   @GetMapping("/zones")
   public ResponseEntity<?> getAll(ProxyExchange<?> proxy,
       @RequestHeader HttpHeaders headers,
-      @RequestParam MultiValueMap<String,String> queryParams) {
+      @RequestParam MultiValueMap<String,String> queryParams,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
@@ -75,7 +79,7 @@ public class ZonesController {
         .buildAndExpand()
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri)
         .get();
@@ -83,7 +87,8 @@ public class ZonesController {
 
   @PostMapping("/zones")
   public ResponseEntity<?> create(ProxyExchange<?> proxy,
-      @RequestHeader HttpHeaders headers) {
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
@@ -91,7 +96,7 @@ public class ZonesController {
         .buildAndExpand()
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri)
         .post();
@@ -99,7 +104,8 @@ public class ZonesController {
 
   @PutMapping("/zones/**")
   public ResponseEntity<?> update(ProxyExchange<?> proxy,
-      @RequestHeader HttpHeaders headers) {
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String zone = proxy.path("/api/zones/");
 
     final String backendUri = UriComponentsBuilder
@@ -108,7 +114,7 @@ public class ZonesController {
         .buildAndExpand(zone)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri)
         .put();
@@ -116,7 +122,8 @@ public class ZonesController {
 
   @DeleteMapping("/zones/**")
   public ResponseEntity<?> delete(ProxyExchange<?> proxy,
-      @RequestHeader HttpHeaders headers) {
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String zone = proxy.path("/api/zones/");
 
     final String backendUri = UriComponentsBuilder
@@ -125,14 +132,15 @@ public class ZonesController {
         .buildAndExpand(zone)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).delete();
   }
 
   @GetMapping("/zone-assignment-counts/**")
   public ResponseEntity<?> getPublicZoneAssignmentCountsForZone(ProxyExchange<?> proxy,
-      @RequestHeader HttpHeaders headers) {
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     String zone = proxy.path("/api/zone-assignment-counts/");
 
     final String backendUri = UriComponentsBuilder
@@ -141,28 +149,30 @@ public class ZonesController {
         .buildAndExpand(zone)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
 
   @GetMapping("/zone-assignment-counts")
   public ResponseEntity<?> getAllPublicZoneAssignmentCounts(ProxyExchange<?> proxy,
-      @RequestHeader HttpHeaders headers) {
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
         .path("/api/admin/zone-assignment-counts")
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
 
   @PostMapping("/rebalance-zone/**")
   public ResponseEntity<?> rebalancePublicZone(ProxyExchange<?> proxy,
-      @RequestHeader HttpHeaders headers) {
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     String zone = proxy.path("/api/rebalance-zone/");
 
     final String backendUri = UriComponentsBuilder
@@ -171,7 +181,7 @@ public class ZonesController {
         .buildAndExpand(zone)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri)
         // no body needed for this operation, but proxy wants to resolve one

--- a/admin/src/main/resources/application-dev.yml
+++ b/admin/src/main/resources/application-dev.yml
@@ -7,6 +7,11 @@ salus:
   api:
     admin:
       roles: ["MONITORING_SERVICE_ADMIN"]
+  identity:
+    endpoint:
+    admin-username:
+    admin-password:
+
 salus.services:
     monitor-management-url: http://localhost:8089
     resource-management-url: http://localhost:8085

--- a/admin/src/test/java/com/rackspace/salus/telemetry/api/ZonesControllerTest.java
+++ b/admin/src/test/java/com/rackspace/salus/telemetry/api/ZonesControllerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import com.rackspace.salus.telemetry.api.config.ServicesProperties;
 import com.rackspace.salus.telemetry.api.web.ZonesController;
+import java.util.HashMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -72,43 +73,43 @@ public class ZonesControllerTest {
 
   @Test
   public void testAllGetPublicZones() {
-    zonesController.getAll(proxyExchange, new HttpHeaders(), new LinkedMultiValueMap<>());
+    zonesController.getAll(proxyExchange, new HttpHeaders(), new LinkedMultiValueMap<>(), new HashMap<>());
     verify(proxyExchange).uri("http://test/api/admin/zones");
   }
 
   @Test
   public void testGetPublicZone() {
-    zonesController.get(proxyExchange, new HttpHeaders(), new LinkedMultiValueMap<>());
+    zonesController.get(proxyExchange, new HttpHeaders(), new LinkedMultiValueMap<>(), new HashMap<>());
     verify(proxyExchange).uri("http://test/api/admin/zones/public/dev");
   }
 
   @Test
   public void testCreatePublicZone() {
-    zonesController.create(proxyExchange, new HttpHeaders());
+    zonesController.create(proxyExchange, new HttpHeaders(), new HashMap<>());
     verify(proxyExchange).uri("http://test/api/admin/zones");
   }
 
   @Test
   public void testUpdatePublicZone() {
-    zonesController.update(proxyExchange, new HttpHeaders());
+    zonesController.update(proxyExchange, new HttpHeaders(), new HashMap<>());
     verify(proxyExchange).uri("http://test/api/admin/zones/public/dev");
   }
 
   @Test
   public void testDeletePublicZone() {
-    zonesController.delete(proxyExchange, new HttpHeaders());
+    zonesController.delete(proxyExchange, new HttpHeaders(), new HashMap<>());
     verify(proxyExchange).uri("http://test/api/admin/zones/public/dev");
   }
 
   @Test
   public void testGetPublicZoneAssignmentCounts() {
-    zonesController.getPublicZoneAssignmentCountsForZone(proxyExchange, new HttpHeaders());
+    zonesController.getPublicZoneAssignmentCountsForZone(proxyExchange, new HttpHeaders(), new HashMap<>());
     verify(proxyExchange).uri("http://test/api/admin/zone-assignment-counts/public/dev");
   }
 
   @Test
   public void testRebalancePublicZone() {
-    zonesController.rebalancePublicZone(proxyExchange, new HttpHeaders());
+    zonesController.rebalancePublicZone(proxyExchange, new HttpHeaders(), new HashMap<>());
     verify(proxyExchange).uri("http://test/api/admin/rebalance-zone/public/dev");
   }
 }

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/TelemetryPublicApiApplication.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/TelemetryPublicApiApplication.java
@@ -16,10 +16,13 @@
 
 package com.rackspace.salus.telemetry.api;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rackspace.salus.common.config.AutoConfigureSalusAppMetrics;
 import com.rackspace.salus.common.util.DumpConfigProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import com.rackspace.salus.common.config.AutoConfigureSalusAppMetrics;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
 @AutoConfigureSalusAppMetrics
@@ -29,5 +32,15 @@ public class TelemetryPublicApiApplication {
     DumpConfigProperties.process(args);
 
     SpringApplication.run(TelemetryPublicApiApplication.class, args);
+  }
+
+  @Bean
+  public RestTemplate getRestTemplate() {
+    return new RestTemplate();
+  }
+
+  @Bean
+  public ObjectMapper getObjectMapper() {
+    return new ObjectMapper();
   }
 }

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/AgentHistoryController.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/AgentHistoryController.java
@@ -18,15 +18,18 @@ package com.rackspace.salus.telemetry.api.web;
 
 import com.rackspace.salus.common.util.ApiUtils;
 import com.rackspace.salus.telemetry.api.config.ServicesProperties;
+import java.util.Map;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.mvc.ProxyExchange;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -34,6 +37,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 @RestController
 @Slf4j
+@PreAuthorize("{#tenantId == authentication.principal}")
 public class AgentHistoryController {
 
   private final ServicesProperties servicesProperties;
@@ -47,7 +51,8 @@ public class AgentHistoryController {
   public ResponseEntity<?> getAgentHistoryForTenant(ProxyExchange<?> proxy,
       @PathVariable String tenantId,
       @RequestHeader HttpHeaders headers,
-      @RequestParam MultiValueMap<String,String> queryParams) {
+      @RequestParam MultiValueMap<String,String> queryParams,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getAmbassadorServiceUrl())
@@ -56,7 +61,7 @@ public class AgentHistoryController {
         .buildAndExpand(tenantId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
@@ -66,7 +71,8 @@ public class AgentHistoryController {
       @PathVariable String tenantId,
       @PathVariable UUID uuid,
       @RequestHeader HttpHeaders headers,
-      @RequestParam MultiValueMap<String,String> queryParams) {
+      @RequestParam MultiValueMap<String,String> queryParams,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getAmbassadorServiceUrl())
@@ -75,7 +81,7 @@ public class AgentHistoryController {
         .buildAndExpand(tenantId, uuid)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/AgentInstallationController.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/AgentInstallationController.java
@@ -18,16 +18,19 @@ package com.rackspace.salus.telemetry.api.web;
 
 import com.rackspace.salus.common.util.ApiUtils;
 import com.rackspace.salus.telemetry.api.config.ServicesProperties;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.mvc.ProxyExchange;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -39,6 +42,7 @@ import org.springframework.web.util.UriComponentsBuilder;
  */
 @RestController
 @Slf4j
+@PreAuthorize("{#tenantId == authentication.principal}")
 public class AgentInstallationController {
 
   private final ServicesProperties servicesProperties;
@@ -50,9 +54,10 @@ public class AgentInstallationController {
 
   @GetMapping("/tenant/{tenantId}/agent-installs")
   public ResponseEntity<?> getAllAgentInstallations(ProxyExchange<?> proxy,
-                                                    @PathVariable String tenantId,
-                                                    @RequestHeader HttpHeaders headers,
-                                                    @RequestParam MultiValueMap<String,String> queryParams) {
+      @PathVariable String tenantId,
+      @RequestHeader HttpHeaders headers,
+      @RequestParam MultiValueMap<String, String> queryParams,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getAgentCatalogManagementUrl())
@@ -61,15 +66,16 @@ public class AgentInstallationController {
         .buildAndExpand(tenantId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
 
   @PostMapping("/tenant/{tenantId}/agent-installs")
   public ResponseEntity<?> installAgentRelease(ProxyExchange<?> proxy,
-                                               @PathVariable String tenantId,
-                                               @RequestHeader HttpHeaders headers) {
+      @PathVariable String tenantId,
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getAgentCatalogManagementUrl())
@@ -77,23 +83,24 @@ public class AgentInstallationController {
         .buildAndExpand(tenantId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).post();
   }
 
   @DeleteMapping("/tenant/{tenantId}/agent-installs/{agentInstallId}")
   public ResponseEntity<?> uninstallAgentRelease(ProxyExchange<?> proxy,
-                                                 @PathVariable String tenantId,
-                                                 @PathVariable String agentInstallId,
-                                                 @RequestHeader HttpHeaders headers) {
+      @PathVariable String tenantId,
+      @PathVariable String agentInstallId,
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getAgentCatalogManagementUrl())
         .path("/api/tenant/{tenantId}/agent-installs/{agentInstallId}")
-        .buildAndExpand(tenantId,agentInstallId)
+        .buildAndExpand(tenantId, agentInstallId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).delete();
   }

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/AgentReleaseController.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/AgentReleaseController.java
@@ -18,19 +18,23 @@ package com.rackspace.salus.telemetry.api.web;
 
 import com.rackspace.salus.common.util.ApiUtils;
 import com.rackspace.salus.telemetry.api.config.ServicesProperties;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.mvc.ProxyExchange;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @RestController
+@PreAuthorize("{#tenantId == authentication.principal}")
 public class AgentReleaseController {
 
   private final ServicesProperties servicesProperties;
@@ -42,9 +46,10 @@ public class AgentReleaseController {
 
   @GetMapping("/tenant/{tenantId}/agent-releases")
   public ResponseEntity<?> getAll(ProxyExchange<?> proxy,
-                                  @PathVariable String tenantId,
-                                  @RequestHeader HttpHeaders headers,
-                                  @RequestParam MultiValueMap<String,String> queryParams) {
+      @PathVariable String tenantId,
+      @RequestHeader HttpHeaders headers,
+      @RequestParam MultiValueMap<String, String> queryParams,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getAgentCatalogManagementUrl())
         .path("/api/tenant/{tenantId}/agent-releases")
@@ -52,23 +57,24 @@ public class AgentReleaseController {
         .buildAndExpand(tenantId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
 
   @GetMapping("/tenant/{tenantId}/event-tasks/agent-releases/{agentReleaseId}")
   public ResponseEntity<?> getOne(ProxyExchange<?> proxy,
-                                  @PathVariable String tenantId,
-                                  @PathVariable String agentReleaseId,
-                                  @RequestHeader HttpHeaders headers) {
+      @PathVariable String tenantId,
+      @PathVariable String agentReleaseId,
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getAgentCatalogManagementUrl())
         .path("/api/tenant/{tenantId}/agent-releases/{agentReleaseId}")
         .buildAndExpand(tenantId, agentReleaseId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/EnvoyTokensController.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/EnvoyTokensController.java
@@ -18,22 +18,26 @@ package com.rackspace.salus.telemetry.api.web;
 
 import com.rackspace.salus.common.util.ApiUtils;
 import com.rackspace.salus.telemetry.api.config.ServicesProperties;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.mvc.ProxyExchange;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @RestController
+@PreAuthorize("{#tenantId == authentication.principal}")
 @SuppressWarnings("Duplicates") // due to repetitive proxy setup/calls
 public class EnvoyTokensController {
 
@@ -43,27 +47,29 @@ public class EnvoyTokensController {
   public EnvoyTokensController(ServicesProperties servicesProperties) {
     this.servicesProperties = servicesProperties;
   }
-  
+
   @PostMapping("/tenant/{tenantId}/envoy-tokens")
   public ResponseEntity<?> create(ProxyExchange<?> proxy,
-                                  @PathVariable String tenantId,
-                                  @RequestHeader HttpHeaders headers) {
+      @PathVariable String tenantId,
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getAuthServiceUrl())
         .path("/api/tenant/{tenantId}/envoy-tokens")
         .buildAndExpand(tenantId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).post();
   }
 
   @GetMapping("/tenant/{tenantId}/envoy-tokens")
   public ResponseEntity<?> getAll(ProxyExchange<?> proxy,
-                                  @PathVariable String tenantId,
-                                  @RequestHeader HttpHeaders headers,
-                                  @RequestParam MultiValueMap<String,String> queryParams) {
+      @PathVariable String tenantId,
+      @RequestHeader HttpHeaders headers,
+      @RequestParam MultiValueMap<String, String> queryParams,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getAuthServiceUrl())
         .path("/api/tenant/{tenantId}/envoy-tokens")
@@ -71,39 +77,41 @@ public class EnvoyTokensController {
         .buildAndExpand(tenantId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
 
   @GetMapping("/tenant/{tenantId}/envoy-tokens/{id}")
   public ResponseEntity<?> getOne(ProxyExchange<?> proxy,
-                                  @PathVariable String tenantId,
-                                  @PathVariable String id,
-                                  @RequestHeader HttpHeaders headers) {
+      @PathVariable String tenantId,
+      @PathVariable String id,
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getAuthServiceUrl())
         .path("/api/tenant/{tenantId}/envoy-tokens/{id}")
         .buildAndExpand(tenantId, id)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
 
   @PutMapping("/tenant/{tenantId}/envoy-tokens/{id}")
   public ResponseEntity<?> update(ProxyExchange<?> proxy,
-                                  @PathVariable String tenantId,
-                                  @PathVariable String id,
-                                  @RequestHeader HttpHeaders headers) {
+      @PathVariable String tenantId,
+      @PathVariable String id,
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getAuthServiceUrl())
         .path("/api/tenant/{tenantId}/envoy-tokens/{id}")
         .buildAndExpand(tenantId, id)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri)
         .put();
@@ -111,16 +119,17 @@ public class EnvoyTokensController {
 
   @DeleteMapping("/tenant/{tenantId}/envoy-tokens/{id}")
   public ResponseEntity<?> delete(ProxyExchange<?> proxy,
-                                  @PathVariable String tenantId,
-                                  @PathVariable String id,
-                                  @RequestHeader HttpHeaders headers) {
+      @PathVariable String tenantId,
+      @PathVariable String id,
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getAuthServiceUrl())
         .path("/api/tenant/{tenantId}/envoy-tokens/{id}")
         .buildAndExpand(tenantId, id)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).delete();
   }

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/EventTasksController.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/EventTasksController.java
@@ -18,23 +18,27 @@ package com.rackspace.salus.telemetry.api.web;
 
 import com.rackspace.salus.common.util.ApiUtils;
 import com.rackspace.salus.telemetry.api.config.ServicesProperties;
+import java.util.Map;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.mvc.ProxyExchange;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @RestController
+@PreAuthorize("{#tenantId == authentication.principal}")
 @SuppressWarnings("Duplicates") // due to repetitive proxy setup/calls
 public class EventTasksController {
 
@@ -47,24 +51,26 @@ public class EventTasksController {
 
   @PostMapping("/tenant/{tenantId}/event-tasks")
   public ResponseEntity<?> create(ProxyExchange<?> proxy,
-                                  @PathVariable String tenantId,
-                                  @RequestHeader HttpHeaders headers) {
+      @PathVariable String tenantId,
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getEventManagementUrl())
         .path("/api/tenant/{tenantId}/tasks")
         .buildAndExpand(tenantId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).post();
   }
 
   @GetMapping("/tenant/{tenantId}/event-tasks")
   public ResponseEntity<?> getAll(ProxyExchange<?> proxy,
-                                  @PathVariable String tenantId,
-                                  @RequestHeader HttpHeaders headers,
-                                  @RequestParam MultiValueMap<String,String> queryParams) {
+      @PathVariable String tenantId,
+      @RequestHeader HttpHeaders headers,
+      @RequestParam MultiValueMap<String, String> queryParams,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getEventManagementUrl())
         .path("/api/tenant/{tenantId}/tasks")
@@ -72,7 +78,7 @@ public class EventTasksController {
         .buildAndExpand(tenantId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
@@ -81,45 +87,48 @@ public class EventTasksController {
   public ResponseEntity<?> getOne(ProxyExchange<?> proxy,
       @PathVariable String tenantId,
       @PathVariable String taskId,
-      @RequestHeader HttpHeaders headers) {
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getEventManagementUrl())
         .path("/api/tenant/{tenantId}/tasks/{taskId}")
         .buildAndExpand(tenantId, taskId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
 
   @DeleteMapping("/tenant/{tenantId}/event-tasks/{taskId}")
   public ResponseEntity<?> delete(ProxyExchange<?> proxy,
-                                  @PathVariable String tenantId,
-                                  @PathVariable String taskId,
-                                  @RequestHeader HttpHeaders headers) {
+      @PathVariable String tenantId,
+      @PathVariable String taskId,
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getEventManagementUrl())
         .path("/api/tenant/{tenantId}/tasks/{taskId}")
         .buildAndExpand(tenantId, taskId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).delete();
   }
 
   @PostMapping("/tenant/{tenantId}/test-event-task")
   public ResponseEntity<?> testEventTask(ProxyExchange<?> proxy,
-                                         @PathVariable String tenantId,
-                                         @RequestHeader HttpHeaders headers) {
+      @PathVariable String tenantId,
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getEventManagementUrl())
         .path("/api/tenant/{tenantId}/test-task")
         .buildAndExpand(tenantId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).post();
   }
@@ -128,14 +137,15 @@ public class EventTasksController {
   public ResponseEntity<?> update(ProxyExchange<?> proxy,
       @PathVariable String tenantId,
       @PathVariable UUID uuid,
-      @RequestHeader HttpHeaders headers) {
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getEventManagementUrl())
         .path("/api/tenant/{tenantId}/tasks/{uuid}")
         .buildAndExpand(tenantId, uuid)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).put();
   }

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorsController.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/MonitorsController.java
@@ -20,6 +20,7 @@ package com.rackspace.salus.telemetry.api.web;
 import com.rackspace.salus.common.util.ApiUtils;
 import com.rackspace.salus.telemetry.api.config.ServicesProperties;
 import java.net.URI;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.mvc.ProxyExchange;
@@ -28,6 +29,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -35,6 +37,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -45,7 +48,9 @@ import org.springframework.web.util.UriComponentsBuilder;
 @RestController
 @Slf4j
 @SuppressWarnings("Duplicates") // due to repetitive proxy setup/calls
+@PreAuthorize("{#tenantId == authentication.principal}")
 public class MonitorsController {
+
   private static final String PATCH_MEDIA_TYPE_VALUE = "application/json-patch+json";
 
   private final ServicesProperties servicesProperties;
@@ -57,9 +62,10 @@ public class MonitorsController {
 
   @GetMapping("/tenant/{tenantId}/monitors")
   public ResponseEntity<?> getAll(ProxyExchange<?> proxy,
-                                  @PathVariable String tenantId,
-                                  @RequestHeader HttpHeaders headers,
-                                  @RequestParam MultiValueMap<String,String> queryParams) {
+      @PathVariable String tenantId,
+      @RequestHeader HttpHeaders headers,
+      @RequestParam MultiValueMap<String, String> queryParams,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final URI backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
         .path("/api/tenant/{tenantId}/monitors")
@@ -67,7 +73,7 @@ public class MonitorsController {
         .buildAndExpand(tenantId)
         .toUri();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
@@ -76,29 +82,31 @@ public class MonitorsController {
   public ResponseEntity<?> get(ProxyExchange<?> proxy,
       @PathVariable String tenantId,
       @RequestHeader HttpHeaders headers,
-      @PathVariable String id) {
+      @PathVariable String id,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
         .path("/api/tenant/{tenantId}/monitors/{uuid}")
         .buildAndExpand(tenantId, id)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
 
   @PostMapping("/tenant/{tenantId}/monitors")
   public ResponseEntity<?> create(ProxyExchange<?> proxy,
-                                  @PathVariable String tenantId,
-                                  @RequestHeader HttpHeaders headers) {
+      @PathVariable String tenantId,
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
         .path("/api/tenant/{tenantId}/monitors")
         .buildAndExpand(tenantId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri)
         .post();
@@ -106,16 +114,17 @@ public class MonitorsController {
 
   @PutMapping("/tenant/{tenantId}/monitors/{id}")
   public ResponseEntity<?> update(ProxyExchange<?> proxy,
-                                  @PathVariable String tenantId,
-                                  @RequestHeader HttpHeaders headers,
-                                  @PathVariable String id) {
+      @PathVariable String tenantId,
+      @RequestHeader HttpHeaders headers,
+      @PathVariable String id,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
         .path("/api/tenant/{tenantId}/monitors/{uuid}")
         .buildAndExpand(tenantId, id)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri)
         .put();
@@ -123,20 +132,20 @@ public class MonitorsController {
 
   /**
    * Proxy exchange does not work with PATCH so we must reconstruct the request instead.
-   *
+   * <p>
    * Related issue: https://github.com/spring-cloud/spring-cloud-netflix/issues/1777
    *
-   * @param body The request body to pass along
+   * @param body     The request body to pass along
    * @param tenantId The tenant id from the url path
-   * @param id The monitor id to update from the url path
+   * @param id       The monitor id to update from the url path
    * @return The String deserialization of the monitor.
    */
   @PatchMapping(path = "/tenant/{tenantId}/monitors/{id}",
-                consumes = PATCH_MEDIA_TYPE_VALUE)
+      consumes = PATCH_MEDIA_TYPE_VALUE)
   public ResponseEntity<String> patch(@RequestHeader HttpHeaders headers,
-                                 @RequestBody String body,
-                                 @PathVariable String tenantId,
-                                 @PathVariable String id) {
+      @RequestBody String body,
+      @PathVariable String tenantId,
+      @PathVariable String id) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
         .path("/api/tenant/{tenantId}/monitors/{uuid}")
@@ -152,66 +161,71 @@ public class MonitorsController {
 
   @DeleteMapping("/tenant/{tenantId}/monitors/{id}")
   public ResponseEntity<?> delete(ProxyExchange<?> proxy,
-                                  @PathVariable String tenantId,
-                                  @RequestHeader HttpHeaders headers,
-                                  @PathVariable String id) {
+      @PathVariable String tenantId,
+      @RequestHeader HttpHeaders headers,
+      @PathVariable String id,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
         .path("/api/tenant/{tenantId}/monitors/{uuid}")
         .buildAndExpand(tenantId, id)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).delete();
   }
 
   @GetMapping("/tenant/{tenantId}/monitor-label-selectors")
   public ResponseEntity<?> getMonitorLabelSelectors(ProxyExchange<?> proxy,
-                                                    @PathVariable String tenantId,
-                                                    @RequestHeader HttpHeaders headers) {
+      @PathVariable String tenantId,
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
         .path("/api/tenant/{tenantId}/monitor-label-selectors")
         .buildAndExpand(tenantId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
 
   @GetMapping("/tenant/{tenantId}/schema/monitor-plugins")
   public ResponseEntity<?> getMonitorPluginsSchema(ProxyExchange<?> proxy,
-                                                   @RequestHeader HttpHeaders headers) {
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
         .path("/schema/monitor-plugins")
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
 
   @GetMapping("/tenant/{tenantId}/schema/monitors")
   public ResponseEntity<?> getMonitorsSchema(ProxyExchange<?> proxy,
-                                             @RequestHeader HttpHeaders headers) {
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
         .path("/schema/monitors")
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
 
   @GetMapping("/tenant/{tenantId}/bound-monitors")
   public ResponseEntity<?> getAllBoundMonitors(ProxyExchange<?> proxy,
-                                               @PathVariable String tenantId,
-                                               @RequestHeader HttpHeaders headers,
-                                               @RequestParam MultiValueMap<String,String> queryParams) {
+      @PathVariable String tenantId,
+      @RequestHeader HttpHeaders headers,
+      @RequestParam MultiValueMap<String, String> queryParams,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final URI backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
         .path("/api/tenant/{tenantId}/bound-monitors")
@@ -219,16 +233,16 @@ public class MonitorsController {
         .buildAndExpand(tenantId)
         .toUri();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
 
-  @GetMapping("/tenant/{tenantId}/monitors-search")
   public ResponseEntity<?> searchMonitors(ProxyExchange<?> proxy,
       @PathVariable String tenantId,
       @RequestHeader HttpHeaders headers,
-      @RequestParam MultiValueMap<String,String> queryParams) {
+      @RequestParam MultiValueMap<String, String> queryParams,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final URI backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
         .path("/api/tenant/{tenantId}/search")
@@ -236,16 +250,16 @@ public class MonitorsController {
         .buildAndExpand(tenantId)
         .toUri();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
 
-  @PostMapping("/tenant/{tenantId}/monitors/{monitorId}/agent-config")
   public ResponseEntity<?> getAgentConfigDetails(ProxyExchange<?> proxy,
       @PathVariable String tenantId,
       @RequestHeader HttpHeaders headers,
-      @PathVariable String monitorId) {
+      @PathVariable String monitorId,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
@@ -253,7 +267,7 @@ public class MonitorsController {
         .buildAndExpand(tenantId, monitorId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri)
         .post();

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/ResourcesController.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/ResourcesController.java
@@ -25,12 +25,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.mvc.ProxyExchange;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -42,6 +44,7 @@ import org.springframework.web.util.UriComponentsBuilder;
  */
 @RestController
 @SuppressWarnings("Duplicates") // due to repetitive proxy setup/calls
+@PreAuthorize("{#tenantId == authentication.principal}")
 public class ResourcesController {
 
   private final ServicesProperties servicesProperties;
@@ -53,9 +56,10 @@ public class ResourcesController {
 
   @GetMapping("/tenant/{tenantId}/resources")
   public ResponseEntity<?> getAll(ProxyExchange<?> proxy,
-                                  @PathVariable String tenantId,
-                                  @RequestHeader HttpHeaders headers,
-                                  @RequestParam MultiValueMap<String,String> queryParams) {
+      @PathVariable String tenantId,
+      @RequestHeader HttpHeaders headers,
+      @RequestParam MultiValueMap<String, String> queryParams,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getResourceManagementUrl())
         .path("/api/tenant/{tenantId}/resources")
@@ -63,7 +67,7 @@ public class ResourcesController {
         .buildAndExpand(tenantId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
@@ -72,7 +76,8 @@ public class ResourcesController {
   public ResponseEntity<?> getOne(ProxyExchange<?> proxy,
       @PathVariable String tenantId,
       @RequestHeader HttpHeaders headers,
-      @PathVariable String resourceId) {
+      @PathVariable String resourceId,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final URI backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getResourceManagementUrl())
@@ -80,17 +85,18 @@ public class ResourcesController {
         .buildAndExpand(tenantId, resourceId)
         .toUri();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
 
   @GetMapping("/tenant/{tenantId}/resources-by-label/{logicalOperator}")
   public ResponseEntity<?> getResourcesWithLabels(ProxyExchange<?> proxy,
-                                                  @PathVariable String tenantId,
-                                                  @PathVariable String logicalOperator,
-                                                  @RequestHeader HttpHeaders headers,
-                                                  @RequestParam Map<String, String> labels) {
+      @PathVariable String tenantId,
+      @PathVariable String logicalOperator,
+      @RequestHeader HttpHeaders headers,
+      @RequestParam Map<String, String> labels,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final UriComponentsBuilder builder = UriComponentsBuilder
         .fromUriString(servicesProperties.getResourceManagementUrl())
         .path("/api/tenant/{tenantId}/resources-by-label/{logicalOperator}");
@@ -101,76 +107,81 @@ public class ResourcesController {
         .buildAndExpand(tenantId, logicalOperator)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
 
   @GetMapping("/tenant/{tenantId}/resource-labels")
   public ResponseEntity<?> getResourceLabels(ProxyExchange<?> proxy,
-                                             @PathVariable String tenantId,
-                                             @RequestHeader HttpHeaders headers) {
+      @PathVariable String tenantId,
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getResourceManagementUrl())
         .path("/api/tenant/{tenantId}/resource-labels")
         .buildAndExpand(tenantId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
 
   @GetMapping("/tenant/{tenantId}/resource-metadata-keys")
   public ResponseEntity<?> getResourceMetadataKeys(ProxyExchange<?> proxy,
-                                                   @PathVariable String tenantId,
-                                                   @RequestHeader HttpHeaders headers) {
+      @PathVariable String tenantId,
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getResourceManagementUrl())
         .path("/api/tenant/{tenantId}/resource-metadata-keys")
         .buildAndExpand(tenantId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
 
   @GetMapping("/tenant/{tenantId}/resource-label-namespaces")
   public ResponseEntity<?> getLabelNamespaces(ProxyExchange<?> proxy,
-                                              @PathVariable String tenantId,
-                                              @RequestHeader HttpHeaders headers) {
+      @PathVariable String tenantId,
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getResourceManagementUrl())
         .path("/api/tenant/{tenantId}/resource-label-namespaces")
         .buildAndExpand(tenantId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
 
   @PostMapping("/tenant/{tenantId}/resources")
   public ResponseEntity<?> create(ProxyExchange<?> proxy,
-                                  @PathVariable String tenantId,
-                                  @RequestHeader HttpHeaders headers) {
+      @PathVariable String tenantId,
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getResourceManagementUrl())
         .path("/api/tenant/{tenantId}/resources")
         .buildAndExpand(tenantId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).post();
   }
 
   @PutMapping("/tenant/{tenantId}/resources/{resourceId}")
   public ResponseEntity<?> update(ProxyExchange<?> proxy,
-                                  @PathVariable String tenantId,
-                                  @PathVariable String resourceId,
-                                  @RequestHeader HttpHeaders headers) {
+      @PathVariable String tenantId,
+      @PathVariable String resourceId,
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final URI backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getResourceManagementUrl())
@@ -178,16 +189,17 @@ public class ResourcesController {
         .buildAndExpand(tenantId, resourceId)
         .toUri();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).put();
   }
 
   @DeleteMapping("/tenant/{tenantId}/resources/{resourceId}")
   public ResponseEntity<?> delete(ProxyExchange<?> proxy,
-                                  @PathVariable String tenantId,
-                                  @PathVariable String resourceId,
-                                  @RequestHeader HttpHeaders headers) {
+      @PathVariable String tenantId,
+      @PathVariable String resourceId,
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final URI backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getResourceManagementUrl())
@@ -195,7 +207,7 @@ public class ResourcesController {
         .buildAndExpand(tenantId, resourceId)
         .toUri();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).delete();
   }
@@ -204,7 +216,8 @@ public class ResourcesController {
   public ResponseEntity<?> searchResources(ProxyExchange<?> proxy,
       @PathVariable String tenantId,
       @RequestHeader HttpHeaders headers,
-      @RequestParam MultiValueMap<String,String> queryParams) {
+      @RequestParam MultiValueMap<String, String> queryParams,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
 
     final URI backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getResourceManagementUrl())
@@ -213,7 +226,7 @@ public class ResourcesController {
         .buildAndExpand(tenantId)
         .toUri();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/TestMonitorController.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/TestMonitorController.java
@@ -21,18 +21,22 @@ import com.rackspace.salus.telemetry.api.config.ServicesProperties;
 import com.rackspace.salus.telemetry.api.model.TestMonitorAndEventTaskRequest;
 import com.rackspace.salus.telemetry.api.model.TestMonitorAndEventTaskResponse;
 import com.rackspace.salus.telemetry.api.services.TestMonitorAndEventTaskService;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.mvc.ProxyExchange;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @RestController
+@PreAuthorize("{#tenantId == authentication.principal}")
 public class TestMonitorController {
 
   private final ServicesProperties servicesProperties;
@@ -48,14 +52,15 @@ public class TestMonitorController {
   @PostMapping("/tenant/{tenantId}/test-monitor")
   public ResponseEntity<?> create(ProxyExchange<?> proxy,
       @PathVariable String tenantId,
-      @RequestHeader HttpHeaders headers) {
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
         .path("/api/tenant/{tenantId}/test-monitor")
         .buildAndExpand(tenantId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri)
         .post();

--- a/public/src/main/java/com/rackspace/salus/telemetry/api/web/ZonesController.java
+++ b/public/src/main/java/com/rackspace/salus/telemetry/api/web/ZonesController.java
@@ -18,17 +18,19 @@ package com.rackspace.salus.telemetry.api.web;
 
 import com.rackspace.salus.common.util.ApiUtils;
 import com.rackspace.salus.telemetry.api.config.ServicesProperties;
-import java.util.Optional;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.mvc.ProxyExchange;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -36,7 +38,9 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 @RestController
 @SuppressWarnings("Duplicates") // due to repetitive proxy setup/calls
+@PreAuthorize("{#tenantId == authentication.principal}")
 public class ZonesController {
+
   private final ServicesProperties servicesProperties;
 
   @Autowired
@@ -46,9 +50,10 @@ public class ZonesController {
 
   @GetMapping("/tenant/{tenantId}/zones")
   public ResponseEntity<?> getAll(ProxyExchange<?> proxy,
-                                  @PathVariable String tenantId,
-                                  @RequestHeader HttpHeaders headers,
-                                  @RequestParam MultiValueMap<String,String> queryParams) {
+      @PathVariable String tenantId,
+      @RequestHeader HttpHeaders headers,
+      @RequestParam MultiValueMap<String, String> queryParams,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
         .path("/api/tenant/{tenantId}/zones")
@@ -56,15 +61,16 @@ public class ZonesController {
         .buildAndExpand(tenantId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
 
   @GetMapping("/tenant/{tenantId}/zones/**")
   public ResponseEntity<?> get(ProxyExchange<?> proxy,
-                               @PathVariable String tenantId,
-                               @RequestHeader HttpHeaders headers) {
+      @PathVariable String tenantId,
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String zone = proxy.path("/api/zones/");
 
     final String backendUri = UriComponentsBuilder
@@ -73,22 +79,23 @@ public class ZonesController {
         .buildAndExpand(tenantId, zone)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
 
   @PostMapping("/tenant/{tenantId}/zones")
   public ResponseEntity<?> create(ProxyExchange<?> proxy,
-                                  @PathVariable String tenantId,
-                                  @RequestHeader HttpHeaders headers) {
+      @PathVariable String tenantId,
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
         .path("/api/tenant/{tenantId}/zones")
         .buildAndExpand(tenantId)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri)
         .post();
@@ -96,16 +103,17 @@ public class ZonesController {
 
   @PutMapping("/tenant/{tenantId}/zones/{name}")
   public ResponseEntity<?> update(ProxyExchange<?> proxy,
-                                  @PathVariable String tenantId,
-                                  @PathVariable String name,
-                                  @RequestHeader HttpHeaders headers) {
+      @PathVariable String tenantId,
+      @PathVariable String name,
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
         .path("/api/tenant/{tenantId}/zones/{name}")
         .buildAndExpand(tenantId, name)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri)
         .put();
@@ -113,31 +121,33 @@ public class ZonesController {
 
   @DeleteMapping("/tenant/{tenantId}/zones/{name}")
   public ResponseEntity<?> delete(ProxyExchange<?> proxy,
-                                  @PathVariable String tenantId,
-                                  @PathVariable String name,
-                                  @RequestHeader HttpHeaders headers) {
+      @PathVariable String tenantId,
+      @PathVariable String name,
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
         .path("/api/tenant/{tenantId}/zones/{name}")
         .buildAndExpand(tenantId, name)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).delete();
   }
 
   @GetMapping("/tenant/{tenantId}/zone-assignment-counts/{name}")
   public ResponseEntity<?> getPrivateZoneAssignmentCountsForZone(ProxyExchange<?> proxy,
-                                                          @PathVariable String tenantId,
-                                                          @PathVariable String name,
-                                                          @RequestHeader HttpHeaders headers) {
+      @PathVariable String tenantId,
+      @PathVariable String name,
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
         .path("/api/tenant/{tenantId}/zone-assignment-counts/{name}")
         .buildAndExpand(tenantId, name)
         .toUriString();
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
@@ -145,29 +155,31 @@ public class ZonesController {
   @GetMapping("/tenant/{tenantId}/zone-assignment-counts")
   public ResponseEntity<?> getAllPrivateZoneAssignmentCounts(ProxyExchange<?> proxy,
       @PathVariable String tenantId,
-      @RequestHeader HttpHeaders headers) {
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
         .path("/api/tenant/{tenantId}/zone-assignment-counts")
         .buildAndExpand(tenantId)
         .toUriString();
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri).get();
   }
 
   @PostMapping("/tenant/{tenantId}/rebalance-zone/{name}")
   public ResponseEntity<?> rebalancePrivateZone(ProxyExchange<?> proxy,
-                                                @PathVariable String tenantId,
-                                                @PathVariable String name,
-                                                @RequestHeader HttpHeaders headers) {
+      @PathVariable String tenantId,
+      @PathVariable String name,
+      @RequestHeader HttpHeaders headers,
+      @RequestAttribute("identityHeadersMap") Map<String, Object> attributes) {
     final String backendUri = UriComponentsBuilder
         .fromUriString(servicesProperties.getMonitorManagementUrl())
         .path("/api/tenant/{tenantId}/rebalance-zone/{name}")
         .buildAndExpand(tenantId, name)
         .toUriString();
 
-    ApiUtils.applyRequiredHeaders(proxy, headers);
+    ApiUtils.applyRequiredHeaders(proxy, headers, attributes);
 
     return proxy.uri(backendUri)
         // no body needed for this operation, but proxy wants to resolve one

--- a/public/src/main/resources/application-dev.yml
+++ b/public/src/main/resources/application-dev.yml
@@ -8,6 +8,11 @@ salus:
   api:
     public:
       roles: ["COMPUTE_DEFAULT", "MONITORING_SERVICE_ADMIN", "IDENTITY_USER_ADMIN", "IDENTITY_DEFAULT"]
+  identity:
+    endpoint:
+    admin-username:
+    admin-password:
+
 salus.services:
   monitor-management-url: http://localhost:8089
   resource-management-url: http://localhost:8085


### PR DESCRIPTION
# Resolves

[SALUS-1077](https://jira.rax.io/browse/SALUS-1077)

# What

Changes corresponding to replacing Repose with IdentityAuthFilter

# How

Added IdentityAuthFilter to validate "x-auth-token" in api header from IdentityApi using admin credentials and then checking for its validity, roles and tenantId(in case of public apis)

